### PR TITLE
[Skill] Add create-widget skill for canvas widget manipulation

### DIFF
--- a/.github/skills/agent-browser/SKILL.md
+++ b/.github/skills/agent-browser/SKILL.md
@@ -28,11 +28,11 @@ Before opening the browser, check for a saved `devURL` in the session database:
 SELECT value FROM session_state WHERE key = 'devURL';
 ```
 
-- **If set** — use that URL as the target.
-- **If the user provided a URL** (e.g. "inspect http://localhost:3000") — use it, and save it as `devURL` for the session:
+- **If the user provided a URL** (e.g. "inspect http://localhost:3000") — assume the dev server is already running at that URL. Use it directly and save it as `devURL` for the session. Do **not** start a dev server.
   ```sql
   INSERT OR REPLACE INTO session_state (key, value) VALUES ('devURL', 'http://localhost:3000');
   ```
+- **If set** — use the saved `devURL`. Assume the dev server is already running.
 - **If neither** — fall back to `http://localhost:1234` and save it as `devURL`.
 
 ### Step 1: Open the dev server

--- a/.github/skills/agent-browser/SKILL.md
+++ b/.github/skills/agent-browser/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: agent-browser
+description: Browser inspection and interaction during development using agent-browser CLI. Use when asked to inspect the browser, check the page, take a screenshot, get the accessibility tree, check for console errors, inspect an element, or see what's on screen.
+---
+
+# Agent Browser
+
+> Triggered by: "inspect the browser", "check the page", "what does the page look like", "browser snapshot", "screenshot the page", "get the accessibility tree", "check for console errors", "inspect element", "check the dev server", "what's on screen"
+
+Uses `agent-browser` to inspect and interact with the running dev server (or any URL) during development. Provides accessibility snapshots, screenshots, console error checking, element inspection, and interactive debugging — all without leaving the terminal.
+
+## Prerequisites
+
+```bash
+npm install -g agent-browser
+agent-browser install  # Downloads Chrome for Testing (first time only)
+```
+
+Both are already installed on this machine.
+
+## Core Workflow
+
+### Step 0: Resolve the target URL
+
+Before opening the browser, check for a saved `devURL` in the session database:
+
+```sql
+SELECT value FROM session_state WHERE key = 'devURL';
+```
+
+- **If set** — use that URL as the target.
+- **If the user provided a URL** (e.g. "inspect http://localhost:3000") — use it, and save it as `devURL` for the session:
+  ```sql
+  INSERT OR REPLACE INTO session_state (key, value) VALUES ('devURL', 'http://localhost:3000');
+  ```
+- **If neither** — fall back to `http://localhost:1234` and save it as `devURL`.
+
+### Step 1: Open the dev server
+
+Open the resolved URL in a headless browser session:
+
+```bash
+agent-browser --session dev open <devURL>
+```
+
+> **Headed mode:** If the user wants to see the browser window, add `--headed`:
+> ```bash
+> agent-browser --session dev --headed open <devURL>
+> ```
+
+> **Navigate to a specific prototype:** Append the prototype path:
+> ```bash
+> agent-browser --session dev open <devURL>/src/prototypes/Example
+> ```
+
+### Step 2: Inspect the page
+
+Choose the right inspection method based on what you need:
+
+#### Accessibility snapshot (best for understanding page structure)
+
+```bash
+agent-browser --session dev snapshot
+```
+
+Options:
+- `-i` — Interactive elements only (buttons, inputs, links)
+- `-c` — Compact (remove empty structural elements)
+- `-d 3` — Limit tree depth
+- `-s "#main"` — Scope to a CSS selector
+
+```bash
+# Common: interactive elements in the main content area
+agent-browser --session dev snapshot -i -c -s "main"
+```
+
+#### Screenshot
+
+```bash
+agent-browser --session dev screenshot /tmp/storyboard-screenshot.png
+```
+
+Options:
+- `--full` — Full page screenshot (not just viewport)
+- `--annotate` — Overlay numbered labels on interactive elements
+
+```bash
+# Annotated screenshot showing all interactive elements
+agent-browser --session dev screenshot --annotate /tmp/storyboard-annotated.png
+```
+
+#### Console errors
+
+```bash
+agent-browser --session dev console
+agent-browser --session dev errors
+```
+
+#### Get element info
+
+```bash
+agent-browser --session dev get text @e1      # Text content by ref
+agent-browser --session dev get html "#main"  # innerHTML by selector
+agent-browser --session dev get title         # Page title
+agent-browser --session dev get url           # Current URL
+```
+
+#### Check element state
+
+```bash
+agent-browser --session dev is visible "#my-element"
+agent-browser --session dev is enabled "#submit-btn"
+```
+
+### Step 3: Interact with the page
+
+After taking a snapshot, use refs (`@e1`, `@e2`, etc.) to interact:
+
+```bash
+agent-browser --session dev click @e2
+agent-browser --session dev fill @e3 "search query"
+agent-browser --session dev hover @e4
+agent-browser --session dev scroll down 300
+```
+
+Or use CSS selectors:
+
+```bash
+agent-browser --session dev click "#sidebar-toggle"
+agent-browser --session dev fill "input[name=search]" "hello"
+```
+
+### Step 4: Navigate
+
+```bash
+agent-browser --session dev open <devURL>/other-page
+agent-browser --session dev back
+agent-browser --session dev forward
+agent-browser --session dev reload
+```
+
+### Step 5: Close the session
+
+```bash
+agent-browser --session dev close
+```
+
+---
+
+## Common Recipes
+
+### Quick page check after a code change
+
+```bash
+agent-browser --session dev open <devURL>
+agent-browser --session dev snapshot -i -c
+agent-browser --session dev errors
+agent-browser --session dev close
+```
+
+### Screenshot + accessibility audit
+
+```bash
+agent-browser --session dev open <devURL>/src/prototypes/Example
+agent-browser --session dev screenshot --annotate /tmp/audit.png
+agent-browser --session dev snapshot
+agent-browser --session dev close
+```
+
+### Debug a specific component
+
+```bash
+agent-browser --session dev open <devURL>/src/prototypes/Example
+agent-browser --session dev snapshot -s "[data-testid=my-component]"
+agent-browser --session dev get html "[data-testid=my-component]"
+agent-browser --session dev close
+```
+
+### Check for JavaScript errors
+
+```bash
+agent-browser --session dev open <devURL>
+agent-browser --session dev wait --load networkidle
+agent-browser --session dev errors
+agent-browser --session dev console
+agent-browser --session dev close
+```
+
+### Batch multiple commands
+
+```bash
+agent-browser --session dev batch \
+  "open <devURL>" \
+  "wait --load networkidle" \
+  "snapshot -i -c" \
+  "errors" \
+  "screenshot /tmp/check.png"
+```
+
+### Viewport emulation
+
+```bash
+agent-browser --session dev set viewport 375 812    # iPhone-sized
+agent-browser --session dev set device "iPhone 14"  # Device preset
+agent-browser --session dev screenshot /tmp/mobile.png
+```
+
+### Network request inspection
+
+```bash
+agent-browser --session dev network requests --type xhr,fetch
+agent-browser --session dev network requests --filter api
+agent-browser --session dev network requests --status 4xx
+```
+
+### Visual diff between two pages
+
+```bash
+agent-browser --session dev diff url <devURL>/page-a <devURL>/page-b --screenshot
+```
+
+---
+
+## Session Management
+
+- **Named sessions** (`--session dev`) keep browser state across commands. Always use `--session dev` for the development workflow.
+- **Reuse sessions:** Don't close and reopen — just navigate with `open` or `goto`.
+- **Multiple sessions:** Use different names if inspecting multiple things at once:
+  ```bash
+  agent-browser --session dev open <devURL>
+  agent-browser --session prod open https://production-url.com
+  ```
+- **List sessions:** `agent-browser session list`
+- **Close all:** `agent-browser close --all`
+
+## Selectors
+
+| Type | Example | Notes |
+|------|---------|-------|
+| Ref | `@e1` | From snapshot output. Deterministic, preferred. |
+| CSS | `"#id"`, `".class"` | Standard CSS selectors |
+| Text | `"text=Submit"` | Match by text content |
+| XPath | `"xpath=//button"` | XPath expressions |
+| Semantic | `find role button --name "Submit"` | ARIA role-based |
+
+> **Prefer refs** (`@e1`) after taking a snapshot — they're deterministic and fast.
+
+## Troubleshooting
+
+- **"No active session"** — Run `agent-browser --session dev open <url>` first
+- **Dev server not running** — Start with `npm run dev` before inspecting
+- **Stale refs** — Take a new `snapshot` after page changes; refs are from the last snapshot
+- **Browser stuck** — `agent-browser close --all` or `agent-browser --session dev close`
+- **Chrome not found** — Run `agent-browser install`
+
+## Repository Cleanup
+
+- Screenshot files in `/tmp/` are ephemeral — no cleanup needed
+- Session data lives in `~/.agent-browser/` — not in the repo
+- Add `agent-browser.json` to `.gitignore` if you create a project-level config

--- a/.github/skills/changelog/SKILL.md
+++ b/.github/skills/changelog/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: changelog
+description: Generates formatted changelog entries from commit ranges. Use when asked to generate a changelog, list what changed, or summarize commits between versions.
+---
+
 # Changelog Skill
 
 > Triggered by: "generate changelog", "create changelog", "changelog since", "changelog between", "what changed since"

--- a/.github/skills/clips/SKILL.md
+++ b/.github/skills/clips/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: clips
+description: Local-first issue tracking workflow for goals and tasks synced to GitHub. Use when creating issues, tracking work, planning tasks, checking status, or managing goals.
+---
+
 # Skill: clips — Issue Tracking
 
 clips is a local-first issue tracker that mirrors GitHub Issues. Data lives in `.clips/db/` as append-only JSONL files. Every mutation syncs to GitHub and commits to git automatically.

--- a/.github/skills/create-widget/SKILL.md
+++ b/.github/skills/create-widget/SKILL.md
@@ -1,0 +1,545 @@
+---
+name: create-widget
+description: Canvas widget manipulation — add, edit, move, remove, and inspect widgets on *.canvas.jsonl canvases. Use when asked to add a sticky note, embed a prototype, place markdown, move widgets, change widget properties, remove widgets, or inspect canvas contents.
+---
+
+# Create Widget
+
+> Triggered by: "add widget", "add a sticky note", "place a note", "embed a prototype", "add markdown", "add a link", "edit widget", "change widget", "move widget", "remove widget", "delete widget", "inspect canvas", "show canvas", "what's on the canvas", "update widget", "resize widget", "change color", "canvas widget"
+
+## What This Does
+
+Manipulates widgets on an existing `*.canvas.jsonl` canvas — adding, editing, moving, removing, and inspecting widgets. Supports all widget types: **sticky notes**, **markdown blocks**, **prototype embeds**, and **link previews**.
+
+This skill handles **widget operations on an existing canvas**. To create a new canvas file, use the **create** skill instead.
+
+**Scope:** This skill manages **JSON-defined mutable widgets** only — the `widgets[]` array in `.canvas.jsonl`. Canvases may also have JSX-backed component widgets (from `.canvas.jsx` companion files) tracked via the `sources[]` array. Those are code-defined and only their **position** is managed in JSONL; their content lives in the `.canvas.jsx` file and is outside the scope of this skill.
+
+---
+
+## Step 0: Detect Operation Mode
+
+Widget operations can be performed via the **Server API** (preferred when dev server is running) or **Direct File Editing** (fallback).
+
+**Always run this check first:**
+
+```bash
+PORT=$(cat .port 2>/dev/null || echo 1234)
+curl -sf "http://localhost:${PORT}/_storyboard/canvas/list" > /dev/null 2>&1 && echo "API" || echo "FILE"
+```
+
+- If `"API"` → use the Server API with `curl` at `http://localhost:${PORT}`
+- If `"FILE"` → edit `.canvas.jsonl` files directly
+
+## Step 0b: Identify the Target Canvas
+
+Before any operation, resolve which canvas to target:
+
+**Via API:** List canvases and let the user disambiguate if needed:
+
+```bash
+PORT=$(cat .port 2>/dev/null || echo 1234)
+curl -s "http://localhost:${PORT}/_storyboard/canvas/list"
+```
+
+If only one canvas exists, use it. If multiple exist and the user didn't specify, ask which one.
+
+**Via file system:** Find all canvas files:
+
+```bash
+find src/canvas -name "*.canvas.jsonl" 2>/dev/null
+```
+
+Canvas files live in `src/canvas/` — either at the root or inside `*.folder/` subdirectories. The canvas name is the filename without the `.canvas.jsonl` suffix (e.g., `src/canvas/design-overview.canvas.jsonl` → name is `design-overview`).
+
+**Important:** Canvas names must be unique by basename. If two canvases share the same name across different folders, the server resolves to the first match found. Always verify with `/list` when ambiguity is possible.
+
+---
+
+## Canvas File Format (`.canvas.jsonl`)
+
+Canvas data is stored as an **append-only JSONL event stream**. Each line is a self-contained JSON object representing an event. The first line is always a `canvas_created` event; subsequent lines are change events. Current state is derived by replaying all events in order.
+
+### Event Types
+
+| Event | Purpose | Key fields |
+|-------|---------|------------|
+| `canvas_created` | Initial state (always line 1) | `title`, `grid`, `gridSize`, `colorMode`, `widgets[]`, `sources[]` |
+| `widget_added` | Append one widget | `widget: {id, type, position, props}` |
+| `widget_updated` | Patch widget props | `widgetId`, `props: {partial}` |
+| `widget_moved` | Update widget position | `widgetId`, `position: {x, y}` |
+| `widget_removed` | Remove a widget by ID | `widgetId` |
+| `widgets_replaced` | Replace entire widgets array | `widgets[]` |
+| `settings_updated` | Patch canvas settings | `settings: {title?, grid?, gridSize?, colorMode?, dotted?, centered?, author?}` |
+| `source_updated` | Replace JSX sources array | `sources[]` |
+
+Every event **must** include an `event` field and a `timestamp` (ISO 8601) field.
+
+### Example file
+
+```jsonl
+{"event":"canvas_created","timestamp":"2026-03-29T22:44:56.978Z","title":"Design Overview","grid":true,"gridSize":24,"colorMode":"auto","widgets":[]}
+{"event":"widget_added","timestamp":"2026-03-29T23:00:00.000Z","widget":{"id":"sticky-note-abc123","type":"sticky-note","position":{"x":100,"y":200},"props":{"text":"Hello world","color":"yellow"}}}
+{"event":"widget_added","timestamp":"2026-03-29T23:01:00.000Z","widget":{"id":"markdown-def456","type":"markdown","position":{"x":400,"y":200},"props":{"content":"## Notes\n\nSome markdown content","width":400}}}
+```
+
+### Position System
+
+- **Origin:** top-left corner of the canvas (0, 0)
+- **Units:** pixels
+- **x** increases to the right, **y** increases downward
+- Positions are rounded to integers
+- Minimum values: `x >= 0`, `y >= 0`
+
+### Widget ID Convention
+
+IDs are generated as `{type}-{random6chars}` using lowercase alphanumeric characters:
+
+```
+sticky-note-abc123
+markdown-def456
+prototype-ghi789
+link-preview-jkl012
+```
+
+When creating widgets via direct file editing, generate a random 6-character suffix:
+
+```bash
+ID="${TYPE}-$(cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 6)"
+```
+
+---
+
+## Widget Types Reference
+
+### 1. Sticky Note (`sticky-note`)
+
+A colored note card with editable text.
+
+| Prop | Type | Category | Default | Constraints |
+|------|------|----------|---------|-------------|
+| `text` | string | content | `""` | Free text, supports newlines |
+| `color` | select | settings | `"yellow"` | One of: `yellow`, `blue`, `green`, `pink`, `purple`, `orange` |
+| `width` | number | size | _(auto)_ | Minimum: 180 |
+| `height` | number | size | _(auto)_ | Minimum: 60 |
+
+**Example widget object:**
+
+```json
+{
+  "id": "sticky-note-abc123",
+  "type": "sticky-note",
+  "position": { "x": 100, "y": 200 },
+  "props": {
+    "text": "Remember to update the API docs",
+    "color": "blue"
+  }
+}
+```
+
+### 2. Markdown Block (`markdown`)
+
+A rendered markdown content block.
+
+| Prop | Type | Category | Default | Constraints |
+|------|------|----------|---------|-------------|
+| `content` | string | content | `""` | Markdown text (headings, bold, italic, code, lists) |
+| `width` | number | size | `360` | Min: 200, Max: 1200 |
+
+**Supported markdown syntax:** `# h1`, `## h2`, `### h3`, `**bold**`, `*italic*`, `` `code` ``, `- list items`, paragraphs (double newline).
+
+**Example widget object:**
+
+```json
+{
+  "id": "markdown-def456",
+  "type": "markdown",
+  "position": { "x": 400, "y": 100 },
+  "props": {
+    "content": "## Component API\n\n- `onClick` — primary action handler\n- `variant` — visual style: **primary**, **secondary**, **danger**",
+    "width": 450
+  }
+}
+```
+
+### 3. Prototype Embed (`prototype`)
+
+An iframe embedding an internal prototype page (or external URL).
+
+| Prop | Type | Category | Default | Constraints |
+|------|------|----------|---------|-------------|
+| `src` | url/path | content | `""` | Prototype route (e.g. `/Example?flow=default`) or full URL |
+| `label` | string | settings | `""` | Display label (falls back to `src`) |
+| `zoom` | number | settings | `100` | Min: 25, Max: 200 (percentage) |
+| `width` | number | size | `800` | Min: 200, Max: 2000 |
+| `height` | number | size | `600` | Min: 200, Max: 1500 |
+
+**`src` format:**
+- Internal prototype: `/<PrototypeName>?flow=<flowName>` (e.g. `/Example?flow=default`)
+- With hash overrides: `/Example?flow=default#user.name=Alice`
+- External URL: `https://example.com` (full URL)
+
+**Example widget object:**
+
+```json
+{
+  "id": "prototype-ghi789",
+  "type": "prototype",
+  "position": { "x": 0, "y": 0 },
+  "props": {
+    "src": "/Signup?flow=Signup/validation-errors",
+    "label": "Signup — Validation Errors",
+    "zoom": 75,
+    "width": 1024,
+    "height": 768
+  }
+}
+```
+
+### 4. Link Preview (`link-preview`)
+
+A card that displays a link with an optional title.
+
+| Prop | Type | Category | Default | Constraints |
+|------|------|----------|---------|-------------|
+| `url` | url | content | `""` | Absolute URL (must include `https://`) |
+| `title` | string | content | `""` | Optional display title |
+
+**Example widget object:**
+
+```json
+{
+  "id": "link-preview-jkl012",
+  "type": "link-preview",
+  "position": { "x": 600, "y": 50 },
+  "props": {
+    "url": "https://primer.style/components",
+    "title": "Primer Components"
+  }
+}
+```
+
+---
+
+## Operations
+
+### Add a Widget
+
+**Via API (preferred):**
+
+```bash
+PORT=$(cat .port 2>/dev/null || echo 1234)
+curl -s -X POST "http://localhost:${PORT}/_storyboard/canvas/widget" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "<canvas-name>",
+    "type": "<widget-type>",
+    "position": { "x": <x>, "y": <y> },
+    "props": { <widget-props> }
+  }'
+```
+
+Response on success: `{"success": true, "widget": {id, type, position, props}}`
+
+The server generates the widget ID automatically.
+
+**Via direct file edit:**
+
+Append a `widget_added` event line to the `.canvas.jsonl` file:
+
+```jsonl
+{"event":"widget_added","timestamp":"<ISO-8601>","widget":{"id":"<type>-<random6>","type":"<widget-type>","position":{"x":<x>,"y":<y>},"props":{<widget-props>}}}
+```
+
+---
+
+### Edit Widget Props
+
+Use this to change text, color, content, URL, zoom, dimensions, or any other widget property.
+
+**Via API (read → modify → write):**
+
+The server has no dedicated widget-update endpoint. You must:
+
+1. **Read** the current state:
+   ```bash
+   PORT=$(cat .port 2>/dev/null || echo 1234)
+   curl -s "http://localhost:${PORT}/_storyboard/canvas/read?name=<canvas-name>"
+   ```
+
+2. **Modify** the target widget's props in the returned `widgets` array (keeping all other widgets unchanged).
+
+3. **Write** the full array back:
+   ```bash
+   curl -s -X PUT "http://localhost:${PORT}/_storyboard/canvas/update" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"<canvas-name>","widgets":[<full-modified-widgets-array>]}'
+   ```
+
+**Critical:** `PUT /update` replaces the **entire** widgets array. Always preserve all widgets you are not modifying.
+
+**Via direct file edit:**
+
+Append a `widget_updated` event (surgical single-widget prop patch — no need to read first):
+
+```jsonl
+{"event":"widget_updated","timestamp":"<ISO-8601>","widgetId":"<widget-id>","props":{"text":"new text"}}
+```
+
+Only include the props you want to change — they are shallow-merged into existing props.
+
+---
+
+### Move a Widget
+
+**Via API (read → modify → write):**
+
+Same pattern as editing: read current state, update the target widget's `position` in the array, write the full array back via `PUT /update`. Preserve all other widgets unchanged.
+
+**Via direct file edit:**
+
+Append a `widget_moved` event (no need to read first):
+
+```jsonl
+{"event":"widget_moved","timestamp":"<ISO-8601>","widgetId":"<widget-id>","position":{"x":<new-x>,"y":<new-y>}}
+```
+
+---
+
+### Remove a Widget
+
+**Via API:**
+
+```bash
+PORT=$(cat .port 2>/dev/null || echo 1234)
+curl -s -X DELETE "http://localhost:${PORT}/_storyboard/canvas/widget" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "<canvas-name>", "widgetId": "<widget-id>"}'
+```
+
+**Via direct file edit:**
+
+Append a `widget_removed` event:
+
+```jsonl
+{"event":"widget_removed","timestamp":"<ISO-8601>","widgetId":"<widget-id>"}
+```
+
+---
+
+### Bulk Update (Multiple Changes at Once)
+
+When making several changes (e.g. repositioning multiple widgets, editing several props), use a single bulk operation instead of multiple individual ones.
+
+**Via API (read → modify → write):**
+
+```bash
+PORT=$(cat .port 2>/dev/null || echo 1234)
+# 1. Read current state
+STATE=$(curl -s "http://localhost:${PORT}/_storyboard/canvas/read?name=<canvas-name>")
+# 2. Extract and modify the widgets array (use jq, python, or node)
+# 3. Send the complete updated widgets array
+curl -s -X PUT "http://localhost:${PORT}/_storyboard/canvas/update" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"<canvas-name>\",\"widgets\":$UPDATED_WIDGETS}"
+```
+
+**Critical:** Always start from the latest state. Never construct a `widgets` array from scratch — you'll lose widgets you didn't know about.
+
+**Via direct file edit:**
+
+For multiple individual changes (e.g. moving two widgets), append separate events:
+
+```jsonl
+{"event":"widget_moved","timestamp":"<ISO-8601>","widgetId":"<id-1>","position":{"x":100,"y":200}}
+{"event":"widget_moved","timestamp":"<ISO-8601>","widgetId":"<id-2>","position":{"x":300,"y":200}}
+```
+
+For coordinated changes requiring atomicity, append a single `widgets_replaced` event with the full updated array. **Read the current state first** (replay the file or use grep) to avoid losing widgets:
+
+```jsonl
+{"event":"widgets_replaced","timestamp":"<ISO-8601>","widgets":[<complete-widgets-array>]}
+```
+
+---
+
+### Read Canvas State (Inspect)
+
+**Via API (preferred):**
+
+```bash
+PORT=$(cat .port 2>/dev/null || echo 1234)
+curl -s "http://localhost:${PORT}/_storyboard/canvas/read?name=<canvas-name>" | python3 -m json.tool
+```
+
+Returns the materialized state: `{title, grid, gridSize, colorMode, widgets[], sources[], ...}`
+
+**Via direct file reading:**
+
+The API does full event replay and materialization. Without it, you can approximate the current widget state:
+
+```bash
+# Get the last full-state snapshot (canvas_created or widgets_replaced)
+tac <file>.canvas.jsonl | grep -m1 -E '"widgets_replaced"|"canvas_created"' | python3 -m json.tool
+```
+
+Then look for any `widget_added`, `widget_updated`, `widget_moved`, or `widget_removed` events that appear **after** that snapshot line. Apply them mentally or via script.
+
+For simple canvases with few events, just reading the whole file works:
+
+```bash
+cat <file>.canvas.jsonl | python3 -c "
+import sys, json
+events = [json.loads(l) for l in sys.stdin if l.strip()]
+# Print last known widgets array
+for e in reversed(events):
+    if 'widgets' in e:
+        print(json.dumps(e['widgets'], indent=2))
+        break
+"
+```
+
+---
+
+## Operation Quick Reference
+
+| Operation | API mode | File mode |
+|-----------|----------|-----------|
+| **Add widget** | `POST /widget` | Append `widget_added` event |
+| **Remove widget** | `DELETE /widget` | Append `widget_removed` event |
+| **Edit props** | `GET /read` → modify → `PUT /update` | Append `widget_updated` event |
+| **Move widget** | `GET /read` → modify → `PUT /update` | Append `widget_moved` event |
+| **Bulk changes** | `GET /read` → modify → `PUT /update` | Append `widgets_replaced` (read first!) |
+| **Read state** | `GET /read?name=X` | Parse file events |
+| **Update settings** | `PUT /update` with `settings` | Append `settings_updated` event |
+
+---
+
+### List All Canvases
+
+**Via API:**
+
+```bash
+PORT=$(cat .port 2>/dev/null || echo 1234)
+curl -s "http://localhost:${PORT}/_storyboard/canvas/list" | python3 -m json.tool
+```
+
+**Via file system:**
+
+```bash
+find src/canvas -name "*.canvas.jsonl" 2>/dev/null
+```
+
+---
+
+### Update Canvas Settings
+
+Change canvas-level settings (title, grid, color mode, etc.):
+
+**Via API:**
+
+```bash
+PORT=$(cat .port 2>/dev/null || echo 1234)
+curl -s -X PUT "http://localhost:${PORT}/_storyboard/canvas/update" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "<canvas-name>",
+    "settings": {
+      "title": "New Title",
+      "grid": true,
+      "gridSize": 24,
+      "colorMode": "auto"
+    }
+  }'
+```
+
+Allowed settings keys: `title`, `description`, `grid`, `gridSize`, `colorMode`, `dotted`, `centered`, `author`.
+
+**Via direct file edit:**
+
+```jsonl
+{"event":"settings_updated","timestamp":"<ISO-8601>","settings":{"title":"New Title"}}
+```
+
+---
+
+## Procedure
+
+### When the user asks to add a widget
+
+1. **Identify the canvas.** If not specified, check if only one canvas exists. If multiple, ask which one.
+2. **Identify the widget type.** Infer from context:
+   - "sticky note", "note", "add a note" → `sticky-note`
+   - "markdown", "text block", "content block" → `markdown`
+   - "embed", "prototype", "iframe", "embed a page" → `prototype`
+   - "link", "URL", "link preview" → `link-preview`
+3. **Gather props from the user's message.** Extract text, colors, URLs, sizes from the request. Use sensible defaults for anything not specified.
+4. **Choose a position.** If the user says "next to", "below", "to the right of" an existing widget, read current state and calculate position relative to that widget. Otherwise use `{x: 100, y: 100}` or space widgets with ~50px gaps.
+5. **Execute the operation** using the API or direct file editing.
+6. **Confirm** what was created, including the widget ID and position.
+
+### When the user asks to edit a widget
+
+1. **Identify the canvas and widget.** Match by ID, type, content, or position description (e.g. "the blue sticky note", "the markdown about API docs").
+2. **Read current state** (required for both API and file mode) to find the target widget and its current props.
+3. **Apply the requested changes** (color, text, content, size, URL, zoom, etc.).
+4. **Execute:**
+   - API: read → modify widgets array → `PUT /update` with full array
+   - File: append `widget_updated` event with only the changed props
+5. **Confirm** what changed.
+
+### When the user asks to move a widget
+
+1. **Identify the widget** as above.
+2. **Read current state** to find the widget's current position.
+3. **Determine the new position.** The user may say absolute coords or relative directions ("move it right", "place it below the prototype embed"). Calculate coordinates accordingly.
+4. **Execute:**
+   - API: read → modify position in widgets array → `PUT /update` with full array
+   - File: append `widget_moved` event
+5. **Confirm** new position.
+
+### When the user asks to remove a widget
+
+1. **Identify the widget** as above.
+2. **Execute** via API `DELETE /widget` or `widget_removed` event.
+3. **Confirm** removal.
+
+### When the user asks to inspect or describe the canvas
+
+1. **Read the current state** via API or file.
+2. **Summarize:** list widget types, counts, brief content preview, positions.
+
+---
+
+## Layout Helpers
+
+When arranging multiple widgets, use these spacing conventions:
+
+- **Horizontal gap between widgets:** 50–100px
+- **Vertical gap between widgets:** 50–100px
+- **Grid alignment:** align to `gridSize` (default 24px) when canvas grid is enabled
+- **Common layouts:**
+  - **Row:** place widgets at same `y`, incrementing `x` by `widget.width + gap`
+  - **Column:** place widgets at same `x`, incrementing `y` by estimated height + gap
+  - **Grid:** combine row and column patterns
+
+**Estimated widget heights** (for layout calculations):
+- Sticky note: 180px (default, or use explicit `height` prop)
+- Markdown: varies by content; estimate ~20px per line of text + 40px padding
+- Prototype embed: use `height` prop (default 600px)
+- Link preview: ~80px
+
+---
+
+## Rules
+
+- **Always read current canvas state before editing or removing** — never guess widget IDs or positions.
+- **Prefer the API** when the dev server is running — it handles ID generation, validation, and materialization.
+- **Use direct file editing only as fallback** when the API is unavailable.
+- **One operation at a time for individual changes**, bulk `widgets_replaced` for multi-widget changes.
+- **Preserve all existing widgets** when doing bulk operations — never drop widgets the user didn't ask to change.
+- **Widget IDs are stable** — once created, a widget's ID doesn't change. Always use the exact ID from the state.
+- **Props are shallow-merged** on `widget_updated` — only include the props you want to change.
+- **Validate prop constraints** before writing (colors must be valid, numbers within min/max ranges, URLs properly formatted).
+- **Canvas files live in `src/canvas/`** — either at the root or inside `*.folder/` directories.
+- **Timestamps must be ISO 8601 format** — use `new Date().toISOString()` or `date -u +"%Y-%m-%dT%H:%M:%S.000Z"`.

--- a/.github/skills/create/SKILL.md
+++ b/.github/skills/create/SKILL.md
@@ -427,7 +427,7 @@ Or if the dev server isn't running, create the file directly at `src/canvas/<nam
 1. Show the created file path and route (`/canvas/<name>`)
 2. Suggest next steps:
    - Run `npm run dev` and navigate to the canvas
-   - Add widgets via the toolbar (sticky notes, markdown, prototypes)
+   - Use the **create-widget** skill to add widgets (sticky notes, markdown, prototype embeds, link previews)
    - Paste URLs to embed prototypes or link previews
 
 ---

--- a/.github/skills/storyboard-core/SKILL.md
+++ b/.github/skills/storyboard-core/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: storyboard-core
+description: Guide for adding CoreUIBar menu buttons and wiring action handlers in the storyboard core package. Use when adding toolbar buttons, menu items, or action handlers to the CoreUIBar.
+---
+
 # Storyboard Core — CoreUIBar & Menu Buttons
 
 Guide for adding new menu buttons to the storyboard CoreUIBar — the floating toolbar at the bottom-right of every prototype page.

--- a/.github/skills/tools/SKILL.md
+++ b/.github/skills/tools/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: tools
+description: Declarative toolbar tool system architecture — config schema, handler modules, surfaces, render types, guards, and context. Use when creating, debugging, or extending toolbar tools.
+---
+
 # Toolbar Tool System
 
 ## Overview

--- a/.github/skills/worktree/SKILL.md
+++ b/.github/skills/worktree/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: worktree
+description: Creates a git worktree in .worktrees/<branch-name> and switches into it. Use when asked to create a worktree, new worktree, or worktree for a branch.
+---
+
 # Worktree Skill
 
 > Triggered by: "create worktree", "new worktree", "worktree for", "worktree"

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ AGENTS_.md
 packages/core/dist/storyboard-ui.*
 
 .clips
+
+# Agent Browser
+agent-browser.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ The default location is in `.github/plans`, but the user may ask for a specific 
 
 - **agent-browser** (`.github/skills/agent-browser/SKILL.md`) — Browser inspection during development using `agent-browser` CLI. Snapshots, screenshots, console errors, element inspection.
 
+- **create-widget** (`.github/skills/create-widget/SKILL.md`) — Canvas widget manipulation: add, edit, move, remove, and inspect widgets on `*.canvas.jsonl` canvases.
+
 ---
 
 ## Build & Development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ The default location is in `.github/plans`, but the user may ask for a specific 
 
 - **ship** (`.github/skills/ship/SKILL.md`) — End-to-end feature shipping: worktree → plan → implement → adversarial review → push → PR. Supports `no-pr` mode to skip the PR step.
 
+- **agent-browser** (`.github/skills/agent-browser/SKILL.md`) — Browser inspection during development using `agent-browser` CLI. Snapshots, screenshots, console errors, element inspection.
+
 ---
 
 ## Build & Development
@@ -57,6 +59,28 @@ npm run dev          # Start dev server at http://localhost:1234
 npm run build        # Production build
 npm run lint         # Run ESLint
 ```
+
+### Dev URL session state
+
+Whenever Copilot starts a dev server (e.g. `npm run dev`), save the URL as `devURL` in the SQL session database:
+
+```sql
+INSERT OR REPLACE INTO session_state (key, value) VALUES ('devURL', 'http://localhost:1234');
+```
+
+This `devURL` is used as the default target by the **agent-browser** skill when the user says "inspect the browser", "check the page", etc. — no URL argument needed.
+
+**How `devURL` gets set:**
+- **Automatically** — when Copilot runs `npm run dev` or any command that starts a dev server, persist the URL to `devURL`.
+- **From user input** — if the user says "the dev server is at http://localhost:3000", save that as `devURL`.
+- **Implicitly from inspection** — if no `devURL` is set and the user says "inspect http://localhost:1234", that URL becomes the `devURL` for the rest of the session.
+
+**How `devURL` gets read:**
+- Before opening a browser with `agent-browser`, always check for a saved `devURL`:
+  ```sql
+  SELECT value FROM session_state WHERE key = 'devURL';
+  ```
+- If set, use it as the default URL. If not set, ask the user or fall back to `http://localhost:1234`.
 
 ---
 


### PR DESCRIPTION
## What

Adds a new `create-widget` skill (\.github/skills/create-widget/SKILL.md) that enables full canvas widget manipulation via natural language.

## Why

Users should be able to add, edit, move, remove, and inspect canvas widgets entirely through Copilot — no UI interaction required. This skill provides the complete reference the agent needs.

## What's in the skill

- **Widget type schemas** — sticky-note, markdown, prototype embed, link-preview with all props, defaults, and constraints
- **Two operation modes** — Server API (preferred when dev server runs) with curl examples, and direct JSONL file editing as fallback
- **Canvas JSONL format** — full event type reference (canvas_created, widget_added, widget_updated, widget_moved, widget_removed, widgets_replaced, settings_updated, source_updated)
- **Operation procedures** — step-by-step for add, edit, move, remove, bulk update, inspect, and canvas settings
- **Safety rules** — read-before-write for API mode, canvas disambiguation, prop validation
- **Layout helpers** — spacing conventions and estimated widget heights for positioning

## Other changes

- Updated `AGENTS.md` to register the new skill
- Updated `create` skill's Canvas Path (Step C6) to cross-reference create-widget for adding widgets