### PR TITLE
fix(viewfinder): eliminate FOUC from duplicate async CSS loading

### DIFF
--- a/packages/core/src/mountStoryboardCore.js
+++ b/packages/core/src/mountStoryboardCore.js
@@ -95,9 +95,19 @@ function applyEarlyTheme() {
 
 /**
  * Inject the compiled UI stylesheet if not already present.
+ * In the source repo, Vite bundles this CSS into the ui-entry chunk
+ * automatically, so this is a no-op. In consumer repos it loads the
+ * pre-compiled dist/storyboard-ui.css.
  */
 async function injectUIStyles() {
   if (document.querySelector('[data-storyboard-ui-css]')) return
+
+  // If the styles are already present from Vite's CSS code-splitting,
+  // skip the redundant import.
+  try {
+    const val = getComputedStyle(document.documentElement).getPropertyValue('--sb--bg')
+    if (val && val.trim()) return
+  } catch { /* fall through */ }
 
   try {
     // Dynamic import of CSS — Vite handles this as a side-effect import.
@@ -151,8 +161,8 @@ export async function mountStoryboardCore(config = {}, options = {}) {
     initCommentsConfig(config, { basePath })
   }
 
-  // Inject compiled UI styles
-  injectUIStyles()
+  // Inject compiled UI styles (await to prevent late restyle / FOUC)
+  await injectUIStyles()
 
   // Load and merge toolbar config.
   // Core defaults come from toolbar.config.json (bundled).

--- a/packages/core/src/svelte-plugin-ui/mount.ts
+++ b/packages/core/src/svelte-plugin-ui/mount.ts
@@ -20,23 +20,50 @@ const STYLE_ID = 'sb-svelte-ui-styles'
 let stylesInjected = false
 
 /**
- * Inject shared base styles (Tachyons + sb-* tokens) into <head>.
- * Idempotent — only injects once per page.
+ * Check whether the shared base styles are already present in the document
+ * (e.g. bundled by Vite's CSS code-splitting for the ui-entry chunk).
  */
-export function injectStyles(): void {
-  if (stylesInjected) return
-  if (typeof document === 'undefined') return
+function stylesAlreadyLoaded(): boolean {
+  if (typeof document === 'undefined') return false
+  // Check for an existing sb- custom property which is defined in the
+  // base stylesheet. If any <style> or <link> already defines it, the
+  // styles are present and we can skip dynamic injection.
+  try {
+    const val = getComputedStyle(document.documentElement).getPropertyValue('--sb--bg')
+    if (val && val.trim()) return true
+  } catch { /* SSR or non-standard env — fall through */ }
+  return false
+}
+
+/**
+ * Inject shared base styles (Tachyons + sb-* tokens) into <head>.
+ * Idempotent — only injects once per page. Returns a promise that
+ * resolves when the stylesheet is ready.
+ */
+export function injectStyles(): Promise<void> {
+  if (stylesInjected) return Promise.resolve()
+  if (typeof document === 'undefined') return Promise.resolve()
   if (document.getElementById(STYLE_ID)) {
     stylesInjected = true
-    return
+    return Promise.resolve()
   }
 
-  const link = document.createElement('link')
-  link.id = STYLE_ID
-  link.rel = 'stylesheet'
-  link.href = new URL('../styles/tailwind.css', import.meta.url).href
-  document.head.appendChild(link)
-  stylesInjected = true
+  // If Vite already bundled the styles into the page, skip the <link>.
+  if (stylesAlreadyLoaded()) {
+    stylesInjected = true
+    return Promise.resolve()
+  }
+
+  return new Promise<void>((resolve) => {
+    const link = document.createElement('link')
+    link.id = STYLE_ID
+    link.rel = 'stylesheet'
+    link.href = new URL('../styles/tailwind.css', import.meta.url).href
+    link.onload = () => resolve()
+    link.onerror = () => resolve() // resolve anyway so the UI still appears
+    document.head.appendChild(link)
+    stylesInjected = true
+  })
 }
 
 export interface PluginHandle {
@@ -44,6 +71,8 @@ export interface PluginHandle {
   destroy: () => void
   /** The wrapper element containing the Svelte component */
   element: HTMLElement
+  /** Resolves when all styles are loaded and the component is ready to show */
+  ready: Promise<void>
 }
 
 /**
@@ -52,14 +81,17 @@ export interface PluginHandle {
  * @param target - DOM element to append the component wrapper to
  * @param ComponentClass - Svelte component constructor
  * @param props - Props to pass to the component
- * @returns Handle with destroy() method
+ * @returns Handle with destroy() method and a `ready` promise
  */
 export function mountSveltePlugin<T extends Record<string, unknown>>(
   target: HTMLElement,
   ComponentClass: Component<T>,
   props?: T,
 ): PluginHandle {
-  injectStyles()
+  // Fire-and-forget — styles are either already present (Vite bundle)
+  // or will load in parallel. The `ready` promise on PluginHandle can
+  // be awaited by callers that need to wait for CSS.
+  const stylesReady = injectStyles()
 
   const wrapper = document.createElement('div')
   wrapper.classList.add('sb-plugin-root')
@@ -73,6 +105,7 @@ export function mountSveltePlugin<T extends Record<string, unknown>>(
 
   return {
     element: wrapper,
+    ready: stylesReady,
     destroy() {
       unmount(instance)
       wrapper.remove()

--- a/packages/react/src/Viewfinder.jsx
+++ b/packages/react/src/Viewfinder.jsx
@@ -45,9 +45,11 @@ export default function Viewfinder({ pageModules = {}, basePath, title = 'Storyb
         showThumbnails,
         hideDefaultFlow: shouldHideDefault,
       })
-      // Reveal after CSS has been processed to prevent FOUC
-      requestAnimationFrame(() => {
-        if (containerRef.current) containerRef.current.style.opacity = '1'
+      // Wait for styles to be fully loaded before revealing
+      handleRef.current.ready.then(() => {
+        requestAnimationFrame(() => {
+          if (containerRef.current) containerRef.current.style.opacity = '1'
+        })
       })
     })
 


### PR DESCRIPTION
## Problem

The viewfinder page shows a flash of unstyled content (FOUC) on production, even with the existing opacity:0 → requestAnimationFrame fix.

## Root Cause

Three independent CSS loading paths were racing to inject the same base styles:

1. **Vite preload** (correct) — `ui-entry.js` statically imports `tailwind.css`, Vite bundles and preloads it before module execution
2. **`injectUIStyles()`** (redundant) — `mountStoryboardCore.js:155` fires a dynamic CSS import without `await`, causing a late restyle
3. **`injectStyles()`** (redundant) — `mount.ts:37` creates a runtime `<link>` tag with no `onload` callback, causing another late restyle

The existing `requestAnimationFrame` reveal fired before paths 2 and 3 completed their network fetches.

## Fix

- **`mount.ts:injectStyles()`** — now detects if styles are already present (via `--sb--bg` CSS custom property) and skips the `<link>` injection. When injection is needed, returns a Promise that resolves on `link.onload`.
- **`mountStoryboardCore.js:injectUIStyles()`** — now `await`ed (was fire-and-forget) and has the same guard to skip when Vite already bundled the styles.
- **`Viewfinder.jsx`** — waits for `handle.ready` (the style-load promise) before revealing the container.
- **`PluginHandle`** interface gains a `ready: Promise<void>` property.

## Files Changed

- `packages/core/src/svelte-plugin-ui/mount.ts` — promise-based style injection with dedup guard
- `packages/core/src/mountStoryboardCore.js` — await CSS injection, add dedup guard
- `packages/react/src/Viewfinder.jsx` — wait for `handle.ready` before reveal