### PR TITLE
feat: system-level Escape to exit widget edit/interactive modes

### DIFF
--- a/.github/plans/3.12.0--exit-modes.md
+++ b/.github/plans/3.12.0--exit-modes.md
@@ -1,0 +1,42 @@
+# Plan: System-level Escape to exit widget modes
+
+## Problem
+Pressing Escape should exit interactive/edit mode on any canvas widget. Currently:
+- **StickyNote** and **MarkdownBlock** handle Escape in their textareas (works)
+- **ComponentWidget** has NO Escape handling (only click-outside)
+- **PrototypeEmbed** handles Escape in edit inputs but NOT for interactive mode (only click-outside)
+
+The behavior should be a **system-level convention** so future editable widgets get it for free.
+
+## Approach
+
+Add a `useWidgetEscape(active, exitFn)` hook that widgets call when they have an active mode. The hook adds a **document-level** `keydown` listener for Escape (only while `active` is true), ensuring it works even when focus is trapped in an iframe or foreign component. This is opt-in per widget but the pattern is minimal (one line).
+
+Additionally, each widget with interactive/edit mode exposes `exitMode()` via `useImperativeHandle` so WidgetChrome can also call it programmatically if needed in the future.
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `widgets/useWidgetEscape.js` | **New** — shared hook |
+| `widgets/StickyNote.jsx` | Add hook for `editing` state (replaces inline Escape handler) |
+| `widgets/MarkdownBlock.jsx` | Add hook for `editing` state (replaces inline Escape handler) |
+| `widgets/ComponentWidget.jsx` | Add hook for `interactive` state |
+| `widgets/PrototypeEmbed.jsx` | Add hook for `interactive` AND `editing` states |
+
+## Steps
+
+1. Create `useWidgetEscape(active, exitFn)` hook
+   - When `active=true`, add document `keydown` listener
+   - On Escape: call `exitFn()`, stop propagation to prevent CanvasPage from interpreting it
+2. Wire hook into each widget:
+   - **StickyNote**: `useWidgetEscape(editing, () => setEditing(false))` — remove inline Escape handler from textarea
+   - **MarkdownBlock**: same pattern — remove inline Escape handler from textarea
+   - **ComponentWidget**: `useWidgetEscape(interactive, () => setInteractive(false))`
+   - **PrototypeEmbed**: two calls — one for `interactive`, one for `editing` (calls `handleCancelEdit`)
+3. Write tests for `useWidgetEscape`
+
+## Edge cases
+- Multiple widgets: only the one(s) with `active=true` listen — others are no-ops
+- Textarea Escape: hook fires AND blur fires if textarea loses focus — `setEditing(false)` is idempotent, no issue
+- Iframe focus: document-level listener fires even when iframe has focus (keydown on parent document works when Escape is pressed outside iframe; when focus is inside iframe, Escape doesn't propagate to parent — but click-outside already covers that case)

--- a/packages/react/src/canvas/widgets/ComponentWidget.jsx
+++ b/packages/react/src/canvas/widgets/ComponentWidget.jsx
@@ -1,6 +1,7 @@
 import { useRef, useCallback, useState, useEffect } from 'react'
 import WidgetWrapper from './WidgetWrapper.jsx'
 import ResizeHandle from './ResizeHandle.jsx'
+import useWidgetEscape from './useWidgetEscape.js'
 import styles from './ComponentWidget.module.css'
 
 /**
@@ -14,6 +15,8 @@ import styles from './ComponentWidget.module.css'
 export default function ComponentWidget({ component: Component, width, height, onUpdate }) {
   const containerRef = useRef(null)
   const [interactive, setInteractive] = useState(false)
+  const exitInteractive = useCallback(() => setInteractive(false), [])
+  useWidgetEscape(interactive, exitInteractive)
 
   const handleResize = useCallback((w, h) => {
     onUpdate?.({ width: w, height: h })

--- a/packages/react/src/canvas/widgets/MarkdownBlock.jsx
+++ b/packages/react/src/canvas/widgets/MarkdownBlock.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import WidgetWrapper from './WidgetWrapper.jsx'
 import { readProp, markdownSchema } from './widgetProps.js'
+import useWidgetEscape from './useWidgetEscape.js'
 import styles from './MarkdownBlock.module.css'
 
 /**
@@ -32,6 +33,8 @@ export default function MarkdownBlock({ props, onUpdate }) {
   const textareaRef = useRef(null)
   const blockRef = useRef(null)
   const [editHeight, setEditHeight] = useState(null)
+  const exitEditing = useCallback(() => setEditing(false), [])
+  useWidgetEscape(editing, exitEditing)
 
   const handleContentChange = useCallback((e) => {
     onUpdate?.({ content: e.target.value })
@@ -69,9 +72,6 @@ export default function MarkdownBlock({ props, onUpdate }) {
             onBlur={() => setEditing(false)}
             onMouseDown={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') setEditing(false)
-            }}
             placeholder="Write markdown…"
           />
         ) : (

--- a/packages/react/src/canvas/widgets/PrototypeEmbed.jsx
+++ b/packages/react/src/canvas/widgets/PrototypeEmbed.jsx
@@ -3,6 +3,7 @@ import { buildPrototypeIndex } from '@dfosco/storyboard-core'
 import WidgetWrapper from './WidgetWrapper.jsx'
 import { readProp, prototypeEmbedSchema } from './widgetProps.js'
 import { getEmbedChromeVars } from './embedTheme.js'
+import useWidgetEscape from './useWidgetEscape.js'
 import styles from './PrototypeEmbed.module.css'
 
 function formatName(name) {
@@ -56,6 +57,11 @@ export default forwardRef(function PrototypeEmbed({ props, onUpdate }, ref) {
   const inputRef = useRef(null)
   const filterRef = useRef(null)
   const embedRef = useRef(null)
+
+  const exitInteractive = useCallback(() => setInteractive(false), [])
+  const exitEditing = useCallback(() => { setEditing(false); setFilter('') }, [])
+  useWidgetEscape(interactive, exitInteractive)
+  useWidgetEscape(editing, exitEditing)
 
   const iframeSrc = useMemo(() => {
     if (!rawSrc) return ''
@@ -246,7 +252,7 @@ export default forwardRef(function PrototypeEmbed({ props, onUpdate }, ref) {
                   value={filter}
                   onChange={(e) => setFilter(e.target.value)}
                   placeholder="Filter…"
-                  onKeyDown={(e) => { if (e.key === 'Escape') handleCancelEdit() }}
+                  onKeyDown={(e) => { if (e.key === 'Escape') exitEditing() }}
                 />
                 <div className={styles.pickerList} role="listbox">
                   {filteredGroups.map((group) => (
@@ -293,7 +299,7 @@ export default forwardRef(function PrototypeEmbed({ props, onUpdate }, ref) {
                 type="text"
                 defaultValue={src}
                 placeholder="/MyPrototype/page"
-                onKeyDown={(e) => { if (e.key === 'Escape') handleCancelEdit() }}
+                onKeyDown={(e) => { if (e.key === 'Escape') exitEditing() }}
               />
               <div className={styles.urlActions}>
                 <button type="submit" className={styles.urlSave}>Save</button>

--- a/packages/react/src/canvas/widgets/StickyNote.jsx
+++ b/packages/react/src/canvas/widgets/StickyNote.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { readProp, stickyNoteSchema } from './widgetProps.js'
 import ResizeHandle from './ResizeHandle.jsx'
+import useWidgetEscape from './useWidgetEscape.js'
 import styles from './StickyNote.module.css'
 
 const COLORS = {
@@ -21,6 +22,8 @@ export default function StickyNote({ props, onUpdate }) {
   const textareaRef = useRef(null)
   const stickyRef = useRef(null)
   const [editing, setEditing] = useState(false)
+  const exitEditing = useCallback(() => setEditing(false), [])
+  useWidgetEscape(editing, exitEditing)
 
   const handleResize = useCallback((w, h) => {
     onUpdate?.({ width: w, height: h })
@@ -69,9 +72,6 @@ export default function StickyNote({ props, onUpdate }) {
             onBlur={() => setEditing(false)}
             onMouseDown={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') setEditing(false)
-            }}
             placeholder="Type here…"
           />
         )}

--- a/packages/react/src/canvas/widgets/useWidgetEscape.js
+++ b/packages/react/src/canvas/widgets/useWidgetEscape.js
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+
+/**
+ * System-level Escape key handler for canvas widgets.
+ *
+ * When `active` is true (widget is in edit or interactive mode),
+ * registers a document-level keydown listener that calls `exitFn`
+ * on Escape. This works even when focus is trapped in an iframe
+ * or foreign component tree.
+ *
+ * Usage:
+ *   useWidgetEscape(editing, () => setEditing(false))
+ *
+ * @param {boolean} active - Whether the widget is in an active mode
+ * @param {() => void} exitFn - Callback to exit the mode
+ */
+export default function useWidgetEscape(active, exitFn) {
+  useEffect(() => {
+    if (!active) return
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        exitFn()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [active, exitFn])
+}

--- a/packages/react/src/canvas/widgets/useWidgetEscape.js
+++ b/packages/react/src/canvas/widgets/useWidgetEscape.js
@@ -5,8 +5,12 @@ import { useEffect } from 'react'
  *
  * When `active` is true (widget is in edit or interactive mode),
  * registers a document-level keydown listener that calls `exitFn`
- * on Escape. This works even when focus is trapped in an iframe
- * or foreign component tree.
+ * on Escape. Uses bubble phase so child components (menus, popovers)
+ * can handle Escape first — only fires if nothing else stops propagation.
+ *
+ * Limitation: does NOT work when focus is inside an iframe (events stay
+ * in the iframe's browsing context). Widgets with iframes should keep
+ * a click-outside handler as a fallback for exiting interactive mode.
  *
  * Usage:
  *   useWidgetEscape(editing, () => setEditing(false))

--- a/packages/react/src/canvas/widgets/useWidgetEscape.test.js
+++ b/packages/react/src/canvas/widgets/useWidgetEscape.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
+import useWidgetEscape from './useWidgetEscape.js'
+
+describe('useWidgetEscape', () => {
+  it('calls exitFn when Escape is pressed while active', () => {
+    const exitFn = vi.fn()
+    renderHook(() => useWidgetEscape(true, exitFn))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(exitFn).toHaveBeenCalledOnce()
+  })
+
+  it('does not call exitFn when active is false', () => {
+    const exitFn = vi.fn()
+    renderHook(() => useWidgetEscape(false, exitFn))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(exitFn).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-Escape keys', () => {
+    const exitFn = vi.fn()
+    renderHook(() => useWidgetEscape(true, exitFn))
+
+    fireEvent.keyDown(document, { key: 'Enter' })
+    fireEvent.keyDown(document, { key: 'a' })
+
+    expect(exitFn).not.toHaveBeenCalled()
+  })
+
+  it('stops listening when active changes from true to false', () => {
+    const exitFn = vi.fn()
+    const { rerender } = renderHook(
+      ({ active }) => useWidgetEscape(active, exitFn),
+      { initialProps: { active: true } }
+    )
+
+    // Active — should respond
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(exitFn).toHaveBeenCalledOnce()
+
+    // Deactivate
+    rerender({ active: false })
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(exitFn).toHaveBeenCalledOnce() // still 1, no new call
+  })
+
+  it('starts listening when active changes from false to true', () => {
+    const exitFn = vi.fn()
+    const { rerender } = renderHook(
+      ({ active }) => useWidgetEscape(active, exitFn),
+      { initialProps: { active: false } }
+    )
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(exitFn).not.toHaveBeenCalled()
+
+    rerender({ active: true })
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(exitFn).toHaveBeenCalledOnce()
+  })
+
+  it('stops propagation of the Escape event', () => {
+    const exitFn = vi.fn()
+    renderHook(() => useWidgetEscape(true, exitFn))
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    const stopSpy = vi.spyOn(event, 'stopPropagation')
+
+    document.dispatchEvent(event)
+
+    expect(stopSpy).toHaveBeenCalled()
+  })
+
+  it('cleans up listener on unmount', () => {
+    const exitFn = vi.fn()
+    const { unmount } = renderHook(() => useWidgetEscape(true, exitFn))
+
+    unmount()
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(exitFn).not.toHaveBeenCalled()
+  })
+})

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,25 +4,21 @@
 import { components, hooks, utils } from '@generouted/react-router/client'
 
 export type Path =
-    | `///src/prototypes`
-    | `///src/prototypes/main/folder/Example`
-    | `///src/prototypes/main/folder/Example/Forms`
-    | `///src/prototypes/main/folder/Example/posts`
-    | `///src/prototypes/main/folder/Example/posts/:id`
-    | `///src/prototypes/main/folder/Signup`
-    | `///src/prototypes/main/folder/Signup/Dashboard`
-    | `///src/prototypes/main/folder/Signup/templates/CloudApp/Application`
+  | `///src/prototypes`
+  | `///src/prototypes/main/folder/Example`
+  | `///src/prototypes/main/folder/Example/Forms`
+  | `///src/prototypes/main/folder/Example/posts`
+  | `///src/prototypes/main/folder/Example/posts/:id`
+  | `///src/prototypes/main/folder/Signup`
+  | `///src/prototypes/main/folder/Signup/Dashboard`
+  | `///src/prototypes/main/folder/Signup/templates/CloudApp/Application`
 
 export type Params = {
-    '///src/prototypes/main/folder/Example/posts/:id': { id: string }
+  '///src/prototypes/main/folder/Example/posts/:id': { id: string }
 }
 
 export type ModalPath = never
 
 export const { Link, Navigate } = components<Path, Params>()
-export const { useModals, useNavigate, useParams } = hooks<
-    Path,
-    Params,
-    ModalPath
->()
+export const { useModals, useNavigate, useParams } = hooks<Path, Params, ModalPath>()
 export const { redirect } = utils<Path, Params>()


### PR DESCRIPTION
## Summary

Adds a `useWidgetEscape(active, exitFn)` hook — a document-level `keydown` listener for Escape that activates only when a widget is in edit/interactive mode. Future widgets get Escape support with one line.

### Wired into all 4 editable widgets

- **StickyNote** — exits editing (replaces inline handler)
- **MarkdownBlock** — exits editing (replaces inline handler)
- **ComponentWidget** — exits interactive mode (new — was click-outside only)
- **PrototypeEmbed** — exits both interactive and editing modes

### Design notes

- Uses **bubble phase** intentionally — child components (menus, popovers) can handle Escape first
- Does **not** work when focus is inside an iframe (browser limitation) — widgets with iframes keep click-outside as fallback
- 7 tests covering active/inactive states, key filtering, lifecycle, propagation, and cleanup