### PR TITLE
docs: update architecture docs for core batch 2

### DIFF
--- a/.github/architecture/packages/core/src/commandActions.js.md
+++ b/.github/architecture/packages/core/src/commandActions.js.md
@@ -1,0 +1,90 @@
+# `packages/core/src/commandActions.js`
+
+<!--
+source: packages/core/src/commandActions.js
+category: storyboard
+importance: high
+-->
+
+> [← Architecture Index](../../../../architecture.index.md)
+
+## Goal
+
+Config-driven registry for command menu entries in the storyboard toolbar. The command section of `toolbar.config.json` declares action metadata (id, label, type, modes, excludeRoutes), and plugins wire up handlers at runtime. Supports three handler shapes: default (`() => void`), toggle (`{ execute(), getState() }`), and submenu (`{ getChildren() }`). Also supports dynamic actions that are registered at runtime and inserted before the footer in the menu.
+
+The module provides mode-aware filtering (actions declare which modes they appear in via a `modes` array), route-based exclusion (via `excludeRoutes` regex patterns matched against the app-relative pathname), and a reactive subscription system compatible with React's `useSyncExternalStore`.
+
+## Composition
+
+### Initialization
+
+**`initCommandActions(config)`** — Seeds the registry from a menu config object (typically from `toolbar.config.json`). Called once at app startup.
+
+```js
+export function initCommandActions(config) {
+  _config = { ...config }
+  _notify()
+}
+```
+
+### Handler Registration
+
+**`registerCommandAction(id, handler)`** — Register a handler for a declared action. Handler can be a plain function, a toggle object with `execute()`/`getState()`, or a submenu object with `getChildren()`.
+
+**`unregisterCommandAction(id)`** — Remove a previously registered handler.
+
+### Dynamic Actions
+
+**`setDynamicActions(group, actions, handlers?)`** — Add runtime actions (e.g., comments menu items) grouped by a key for bulk replacement. Previous entries for the group are removed first.
+
+```js
+export function setDynamicActions(group, actions, handlers = {}) {
+  _dynamicActions = _dynamicActions.filter(a => a._group !== group)
+  for (const action of actions) {
+    _dynamicActions.push({ ...action, type: action.type || 'default', _group: group })
+  }
+  for (const [id, handler] of Object.entries(handlers)) {
+    _handlers.set(id, handler)
+  }
+  _notify()
+}
+```
+
+**`clearDynamicActions(group)`** — Remove all dynamic actions and their handlers for a group.
+
+### Resolution
+
+**`setRoutingBasePath(basePath)`** — Sets the base path used for route exclusion matching (strips the base so patterns match app-relative paths).
+
+**`isExcludedByRoute(item)`** — Checks if an item's `excludeRoutes` regex patterns match the current pathname (after stripping the base path).
+
+**`getActionsForMode(mode)`** — Returns resolved actions for the current mode. Filters config actions by mode visibility and route exclusion, inserts dynamic actions before the footer, and attaches handler references and toggle state.
+
+**`executeAction(id)`** — Executes an action by id — calls the handler function or its `execute()` method.
+
+**`getActionChildren(id)`** — Returns submenu children from a submenu-type handler's `getChildren()`.
+
+**`hasChildrenProvider(id)`** — Checks if a handler has `getChildren`, used by [`CoreUIBar.svelte`](./CoreUIBar.svelte.md) to distinguish action-menu tools from custom-component menus.
+
+### Reactivity
+
+**`subscribeToCommandActions(callback)`** / **`getCommandActionsSnapshot()`** — Compatible with `useSyncExternalStore`. Snapshot is an incrementing version number.
+
+**`_resetCommandActions()`** — Test-only helper that clears all internal state.
+
+## Dependencies
+
+No external dependencies. Pure JavaScript module.
+
+## Dependents
+
+- [`packages/core/src/index.js`](./index.js.md) — Re-exports all public functions
+- `packages/core/src/CoreUIBar.svelte` — Imports action resolution and execution for the command menu UI
+- `packages/core/src/CommandMenu.svelte` — Imports `getActionsForMode`, `executeAction`, `getActionChildren`
+- `packages/core/src/ActionMenuButton.svelte` — Imports command action functions for action menu buttons
+
+## Notes
+
+- Dynamic actions are inserted before the `footer`-type action in the config, so the footer always stays at the bottom of the menu.
+- Route exclusion uses `RegExp` matching, so patterns like `"^/$"` (root only) or `"^/Signup"` work.
+- The `localOnly` flag on actions indicates they should only appear in local development (not branch deploys).

--- a/.github/architecture/packages/core/src/devtools-consumer.js.md
+++ b/.github/architecture/packages/core/src/devtools-consumer.js.md
@@ -1,0 +1,46 @@
+# `packages/core/src/devtools-consumer.js`
+
+<!--
+source: packages/core/src/devtools-consumer.js
+category: storyboard
+importance: high
+-->
+
+> [← Architecture Index](../../../../architecture.index.md)
+
+## Goal
+
+Consumer-safe proxy for the devtools mount/unmount functions. Delegates to the compiled UI bundle (`@dfosco/storyboard-core/ui-runtime`) so consumer apps don't need Svelte installed as a dependency. The real `mountDevTools` in `devtools.js` imports Svelte directly and is only usable in the source repo or via the compiled UI bundle — this module provides a lazy-loaded bridge.
+
+## Composition
+
+**`mountDevTools(options?)`** — Dynamically imports `@dfosco/storyboard-core/ui-runtime` and delegates to its `mountDevTools`.
+
+**`unmountDevTools()`** — Dynamically imports the UI runtime and delegates to its `unmountDevTools`.
+
+```js
+export async function mountDevTools(options = {}) {
+  const ui = await import('@dfosco/storyboard-core/ui-runtime')
+  return ui.mountDevTools(options)
+}
+
+export async function unmountDevTools() {
+  const ui = await import('@dfosco/storyboard-core/ui-runtime')
+  return ui.unmountDevTools()
+}
+```
+
+**`mountFlowDebug(options?)`** / **`mountSceneDebug(options?)`** — Deprecated aliases for `mountDevTools`.
+
+## Dependencies
+
+- `@dfosco/storyboard-core/ui-runtime` — Compiled Svelte UI bundle (dynamically imported)
+
+## Dependents
+
+- [`packages/core/src/index.js`](./index.js.md) — Re-exports `mountDevTools` for the public API
+
+## Notes
+
+- All imports are dynamic (`import()`) to avoid pulling Svelte into consumer bundles at compile time.
+- In the source repo, Vite alias overrides `@dfosco/storyboard-core/ui-runtime` to the source entry for HMR. In consumer repos, it resolves to the compiled `dist/storyboard-ui.js`.

--- a/.github/architecture/packages/core/src/featureFlags.js.md
+++ b/.github/architecture/packages/core/src/featureFlags.js.md
@@ -10,31 +10,33 @@ importance: high
 
 ## Goal
 
-Feature flag system for Storyboard. Flags are defined in `storyboard.config.json` under `"featureFlags"` and initialized at app startup via the Vite data plugin. The system supports a three-tier read priority (URL hash → localStorage → config defaults) and writes to the URL hash for shareability. All flag keys in hash/localStorage are prefixed with `flag.` to avoid collisions with scene overrides. Active flags are also reflected as `sb-ff-{name}` CSS classes on `<body>`.
+Feature flag system for Storyboard. Flags are defined in `storyboard.config.json` under `"featureFlags"` and initialized at app startup via [`mountStoryboardCore.js`](./mountStoryboardCore.js.md). The system supports a two-tier read priority (localStorage → config defaults) and writes to localStorage for persistence. All flag keys in localStorage are prefixed with `flag.` to avoid collisions with scene overrides. Active flags are also reflected as `sb-ff-{name}` CSS classes on `<body>`.
 
 ## Composition
 
-**`initFeatureFlags(defaults)`** — Seeds the flag system with config defaults. Syncs localStorage with config defaults on every call (user overrides live in the URL hash, which is checked first).
+**`initFeatureFlags(defaults)`** — Seeds the flag system with config defaults. Only writes a default to localStorage when no user override exists yet, so toggled values survive across reloads.
 
 ```js
 export function initFeatureFlags(defaults = {}) {
   _defaults = { ...defaults }
   for (const [key, value] of Object.entries(_defaults)) {
-    setLocal(FLAG_PREFIX + key, String(value))
+    if (getLocal(FLAG_PREFIX + key) === null) {
+      setLocal(FLAG_PREFIX + key, String(value))
+    }
   }
   syncFlagBodyClasses()
 }
 ```
 
-**`getFlag(key)`** — Reads a flag value with priority: hash → localStorage → config default.
+**`getFlag(key)`** — Reads a flag value with priority: localStorage → config default.
 
-**`setFlag(key, value)`** — Writes a flag to URL hash and syncs body classes.
+**`setFlag(key, value)`** — Writes a flag to localStorage and syncs body classes.
 
 **`toggleFlag(key)`** — Reads current value and writes opposite.
 
 **`getAllFlags()`** — Returns all flags with `{ default, current }` values.
 
-**`resetFlags()`** — Removes all hash and localStorage overrides, reverting to config defaults.
+**`resetFlags()`** — Removes all localStorage overrides, reverting to config defaults.
 
 **`getFlagKeys()`** — Returns all registered flag key names.
 
@@ -42,11 +44,12 @@ export function initFeatureFlags(defaults = {}) {
 
 ## Dependencies
 
-- [`packages/core/src/session.js`](./session.js.md) — `getParam`, `setParam`, `removeParam`, `getAllParams` for URL hash read/write
 - [`packages/core/src/localStorage.js`](./localStorage.js.md) — `getLocal`, `setLocal`, `removeLocal`, `getAllLocal` for localStorage persistence
 
 ## Dependents
 
 - [`packages/core/src/index.js`](./index.js.md) — Re-exports all public functions
 - [`packages/core/src/bodyClasses.js`](./bodyClasses.js.md) — Imports `syncFlagBodyClasses` for the combined body class sync
-- [`packages/core/src/devtools.js`](./devtools.js.md) — Imports `getAllFlags`, `toggleFlag`, `getFlagKeys` for the feature flags panel
+- [`packages/core/src/mountStoryboardCore.js`](./mountStoryboardCore.js.md) — Calls `initFeatureFlags` at app startup
+- `packages/core/src/tools/handlers/featureFlags.js` — Feature flags tool handler
+- `packages/core/src/tools/registry.js` — Tool registry references feature flags

--- a/.github/architecture/packages/core/src/loader.test.js.md
+++ b/.github/architecture/packages/core/src/loader.test.js.md
@@ -10,11 +10,11 @@ importance: high
 
 ## Goal
 
-Tests for [`packages/core/src/loader.js`](./loader.js.md). Covers the complete data loading pipeline: `init` (validation, error on null/undefined/string), `loadScene` (basic load, `$ref` resolution, nested `$ref`, `$global` merge with conflict resolution, missing scene, case-insensitive lookup, deep clone isolation, default param, circular `$ref` detection), `sceneExists`, `listScenes`, `loadRecord` (array validation, clone), `findRecord`, and `deepMerge` (nested merge, source wins, array replacement, null handling).
+Tests for [`packages/core/src/loader.js`](./loader.js.md). Covers the complete data loading pipeline: `init` (validation, error on null/undefined/string, backward compat with `{ scenes }`), `loadFlow` (basic load, `$ref` resolution, nested `$ref`, `$global` merge with conflict resolution, missing flow, case-insensitive lookup, deep clone isolation, repeated calls without index mutation, default param, circular `$ref` detection), `flowExists`, `listFlows`, deprecated aliases (`loadScene`, `sceneExists`, `listScenes`), `loadRecord` (array validation, non-array rejection, clone), `findRecord`, `deepMerge` (nested merge, source wins, array replacement, null handling), `loadObject` (basic load, `$ref` within objects, missing object, clone, circular detection), scoped name resolution (`resolveFlowName`, `resolveRecordName`, `resolveObjectName`), scoped object loading with prototype fallback, error hints for scoped data, and folder functions (`listFolders`, `getFolderMetadata`).
 
 ## Composition
 
-Six `describe` blocks. Uses a `makeIndex()` factory to create fresh test data for each test via `beforeEach`. Includes a dedicated circular reference test case with two objects that reference each other.
+Fourteen `describe` blocks organized by feature area. Uses a `makeIndex()` factory to create fresh test data for each test via `beforeEach`. Includes dedicated circular reference test cases with two objects that reference each other, scoped data tests that re-initialize the index with prototype-scoped flows/objects/records, and folder metadata tests.
 
 ## Dependencies
 

--- a/.github/architecture/packages/core/src/modes.js.md
+++ b/.github/architecture/packages/core/src/modes.js.md
@@ -33,9 +33,9 @@ export function registerMode(name, config = {}) {
 
 ### Mode Switching
 
-**`getCurrentMode()`** — Reads `?mode=` from the URL, falls back to `"prototype"`.
+**`getCurrentMode()`** — Reads `?mode=` from the URL, falls back to `"prototype"`. Returns the locked mode if one is set and registered.
 
-**`activateMode(name, options)`** — Switches modes: deactivates previous (removes CSS classes, calls `onDeactivate`), updates URL param, activates new (applies CSS classes, calls `onActivate`), emits events.
+**`activateMode(name, options)`** — Switches modes: deactivates previous (removes CSS classes, calls `onDeactivate`), updates URL param, activates new (applies CSS classes, calls `onActivate`), emits events. No-op when modes are locked.
 
 **`deactivateMode()`** — Returns to the default "prototype" mode.
 
@@ -49,9 +49,13 @@ export function registerMode(name, config = {}) {
 
 ### Configuration
 
-**`initModesConfig(config)`** — Initialize modes from storyboard.config.json. Controls whether modes UI is enabled.
+**`initModesConfig(config)`** — Initialize modes from storyboard.config.json. Controls whether modes UI is enabled and whether modes are locked to a specific mode.
 
 **`isModesEnabled()`** — Returns whether the modes UI should be shown.
+
+**`getLockedMode()`** — Returns the locked mode name, or `null` if modes are not locked. When locked, the mode switcher is hidden and `activateMode()` is a no-op.
+
+**`isModeSwitcherVisible()`** — Returns `false` when modes are disabled or locked to a specific mode.
 
 ### Tool Registry
 

--- a/.github/architecture/packages/core/src/modes.test.js.md
+++ b/.github/architecture/packages/core/src/modes.test.js.md
@@ -10,11 +10,11 @@ importance: high
 
 ## Goal
 
-Tests for [`packages/core/src/modes.js`](./modes.js.md). Comprehensive test suite covering the mode registry (register, overwrite warning, insertion order, unregister, default mode protection), `getCurrentMode` (default fallback, URL param reading, unregistered mode rejection), `activateMode` (URL param update, lifecycle hooks, no-op when already active, unregistered mode warning), `deactivateMode` (return to prototype, URL param removal), subscriptions (callback on activate/register, unsubscribe), snapshot changes, event bus (on/emit/off, error catching), modes config (enabled/disabled, reset), and the full tool registry (initTools, wildcard/mode-specific tools, state management, actions, sorting, snapshots).
+Tests for [`packages/core/src/modes.js`](./modes.js.md). Comprehensive test suite covering the mode registry (register, overwrite warning, insertion order, unregister, default mode protection), `getCurrentMode` (default fallback, URL param reading, unregistered mode rejection), `activateMode` (URL param update, lifecycle hooks, no-op when already active, unregistered mode warning), `deactivateMode` (return to prototype, URL param removal), subscriptions (callback on activate/register, unsubscribe), snapshot changes, event bus (on/emit/off, error catching), modes config (enabled/disabled, reset, default-enabled when no args), locked mode (locked mode getter, `getCurrentMode` with locked mode, fallback when locked mode not registered, `activateMode` no-op when locked, `isModeSwitcherVisible` visibility logic, reset clears locked state), and the full tool registry (initTools, wildcard/mode-specific tools, mode merging, state management with partial updates, actions, sorting by group and order, hidden tool exclusion, snapshots, undeclared tool warnings).
 
 ## Composition
 
-Eight top-level `describe` blocks. Uses `_resetModes()` and URL cleanup in `afterEach`. Tool registry tests use sample tool configs with wildcard (`*`) and mode-specific declarations.
+Nine top-level `describe` blocks. Uses `_resetModes()` and URL cleanup in `afterEach`. Tool registry tests use sample tool configs with wildcard (`*`) and mode-specific declarations. Locked mode tests validate the interaction between `initModesConfig`, `getCurrentMode`, and `activateMode`.
 
 ## Dependencies
 

--- a/.github/architecture/packages/core/src/mountStoryboardCore.js.md
+++ b/.github/architecture/packages/core/src/mountStoryboardCore.js.md
@@ -1,0 +1,93 @@
+# `packages/core/src/mountStoryboardCore.js`
+
+<!--
+source: packages/core/src/mountStoryboardCore.js
+category: storyboard
+importance: high
+-->
+
+> [← Architecture Index](../../../../architecture.index.md)
+
+## Goal
+
+Single entry point for consumer apps to initialize all storyboard systems. `mountStoryboardCore` is called once at app startup with the contents of `storyboard.config.json` and optional runtime options. It orchestrates the initialization of URL state listeners, history sync, body class sync, feature flags, plugins, UI config, comments, toolbar config, theme application, and the compiled Svelte UI (CoreUIBar + comments).
+
+This is the "glue" module — it imports from many core subsystems but contains no domain logic of its own. Its job is to call each subsystem's `init*` function in the correct order, merge toolbar configs, inject repository URLs, and mount the compiled UI bundle.
+
+## Composition
+
+### Early Theme Application
+
+**`applyEarlyTheme()`** — Reads `sb-color-scheme` and `sb-theme-sync` from localStorage and applies Primer CSS `data-*` attributes to `<html>` before any framework mounts. Supports per-target sync settings (prototype, toolbar, codeBoxes, canvas) and the `_sb_theme_target` URL param for forced targeting.
+
+```js
+function applyEarlyTheme() {
+  const stored = localStorage.getItem('sb-color-scheme')
+  const theme = stored || 'system'
+  // Resolves "system" via matchMedia, sets data-sb-theme, data-color-mode, etc.
+}
+```
+
+### Main Mount Function
+
+**`mountStoryboardCore(config, options?)`** — Orchestrates initialization in this order:
+
+1. **Guard** — No-op if already mounted (idempotent via `_mounted` flag)
+2. **Early theme** — `applyEarlyTheme()` prevents flash of wrong theme
+3. **Framework-agnostic systems** — `installHideParamListener()`, `installHistorySync()`, `installBodyClassSync()`
+4. **Config-driven systems** — `initFeatureFlags()`, `initPlugins()`, `initUIConfig()`
+5. **Comments** — `initCommentsConfig()` if configured
+6. **UI styles** — `injectUIStyles()` loads the compiled CSS
+7. **Toolbar config** — Deep-merges `toolbar.config.json` defaults with consumer overrides, injects repository URL
+8. **Toolbar config store** — `initToolbarConfig()` seeds the reactive store
+9. **Embed guard** — Skips UI mounting when `?_sb_embed` is present (prototype embed iframe)
+10. **UI mount** — Dynamically imports `@dfosco/storyboard-core/ui-runtime`, calls `mountDevTools()` and optionally `mountComments()`
+11. **Pending notifications** — Shows toast for workshop creations that survived a Vite reload
+
+```js
+export async function mountStoryboardCore(config = {}, options = {}) {
+  if (_mounted) return
+  _mounted = true
+  const basePath = options.basePath || '/'
+  applyEarlyTheme()
+  installHideParamListener()
+  installHistorySync()
+  installBodyClassSync()
+  if (config.featureFlags) initFeatureFlags(config.featureFlags)
+  // ... toolbar merge, UI mount, comments
+}
+```
+
+### Toolbar Config Merging
+
+The toolbar config is built by deep-merging the bundled `toolbar.config.json` defaults with any consumer-provided `config.toolbar` overrides. Repository URL is injected into both the new tools schema (`toolbarConfig.tools.repository`) and the legacy menus schema (`toolbarConfig.menus.command.actions`).
+
+### Pending Notifications
+
+**`showPendingNotification(basePath)`** — Checks `sessionStorage` for keys like `sb-canvas-created`, `sb-prototype-created`, `sb-flow-created` and shows a temporary toast. This handles the case where Vite does a full reload after file creation, losing the create form's success message.
+
+## Dependencies
+
+- [`packages/core/src/interceptHideParams.js`](./interceptHideParams.js.md) — `installHideParamListener`
+- [`packages/core/src/hideMode.js`](./hideMode.js.md) — `installHistorySync`
+- [`packages/core/src/bodyClasses.js`](./bodyClasses.js.md) — `installBodyClassSync`
+- [`packages/core/src/comments/config.js`](./comments/config.js.md) — `initCommentsConfig`, `isCommentsEnabled`
+- [`packages/core/src/featureFlags.js`](./featureFlags.js.md) — `initFeatureFlags`
+- [`packages/core/src/plugins.js`](./plugins.js.md) — `initPlugins`
+- [`packages/core/src/uiConfig.js`](./uiConfig.js.md) — `initUIConfig`
+- [`packages/core/src/toolbarConfigStore.js`](./toolbarConfigStore.js.md) — `initToolbarConfig`
+- [`packages/core/src/loader.js`](./loader.js.md) — `deepMerge` for toolbar config merging
+- `toolbar.config.json` — Bundled toolbar defaults
+- `@dfosco/storyboard-core/ui-runtime` — Compiled Svelte UI bundle (dynamically imported)
+
+## Dependents
+
+- [`packages/core/src/index.js`](./index.js.md) — Re-exports `mountStoryboardCore` as the public API
+- [`src/index.jsx`](../../../../src/index.jsx.md) — Source repo app entry point calls `mountStoryboardCore`
+
+## Notes
+
+- The `_mounted` flag ensures the function is idempotent — calling it twice is a no-op.
+- When loaded inside a prototype embed iframe (`?_sb_embed`), all UI mounting is skipped. Only framework-agnostic systems and config are initialized.
+- Theme is applied synchronously before any async work to prevent a flash of wrong-theme content.
+- The toast notification uses inline styles and vanilla DOM — no framework dependency.

--- a/.github/architecture/packages/core/src/viewfinder.js.md
+++ b/.github/architecture/packages/core/src/viewfinder.js.md
@@ -10,7 +10,9 @@ importance: high
 
 ## Goal
 
-Provides utility functions for the viewfinder feature: a deterministic hash function for seeding generative placeholders, a route resolver that maps flow names to their target routes, flow metadata extraction, and a prototype index builder. The route resolver supports three strategies: matching against known route names (case-insensitive), reading an explicit `route` key from flow data (checking top-level, `meta`, `flowMeta`, and legacy `sceneMeta`), and falling back to the root path.
+Provides utility functions for the viewfinder feature: a deterministic hash function for seeding generative placeholders, a route resolver that maps flow names to their target routes, flow metadata extraction, and a prototype index builder. The route resolver supports four strategies: matching against known route names (case-insensitive), reading an explicit `route` key from flow data (checking top-level, `meta`, `flowMeta`, and legacy `sceneMeta`), using an inferred `_route` from the Vite data plugin, and falling back to the root path. Flows with `meta.default: true` omit the `?flow=` query param.
+
+The `buildPrototypeIndex` function is the central data source for the viewfinder UI — it groups flows by prototype, prototypes by folder, includes canvas entries, and returns pre-sorted variants by title and last-updated date.
 
 ## Composition
 
@@ -26,7 +28,18 @@ export function hash(str) {
 }
 ```
 
-**`resolveFlowRoute(flowName, knownRoutes?)`** — Resolves the target route path for a flow. Returns a full path with `?flow=` param when needed. If the flow name matches a known route, no query param is needed (StoryboardProvider auto-matches by page name).
+**`resolveFlowRoute(flowName, knownRoutes?)`** — Resolves the target route path for a flow. Returns a full path with `?flow=` param when needed. If the flow name matches a known route, no query param is needed (StoryboardProvider auto-matches by page name). Also checks for `_route` (inferred from file path by the Vite plugin) and omits `?flow=` when `meta.default` is `true`.
+
+```js
+// Priority: known route match → explicit route/meta.route/flowMeta.route → _route → "/"
+export function resolveFlowRoute(flowName, knownRoutes = []) {
+  for (const route of knownRoutes) {
+    if (route.toLowerCase() === flowName.toLowerCase()) return `/${route}`
+  }
+  // ... checks data.route, data.meta.route, data.flowMeta.route, data._route
+  return `/?flow=${encodeURIComponent(flowName)}`
+}
+```
 
 **`resolveSceneRoute`** — Deprecated alias for `resolveFlowRoute`.
 
@@ -34,20 +47,25 @@ export function hash(str) {
 
 **`getSceneMeta`** — Deprecated alias for `getFlowMeta`.
 
-**`buildPrototypeIndex(knownRoutes?)`** — Builds a structured index grouping flows by prototype. Returns `{ prototypes, globalFlows }`. Seeds from `.prototype.json` metadata, supports `hideFlows`, `icon`, `team`, `tags`, and auto-fills `gitAuthor` from the data plugin.
+**`buildPrototypeIndex(knownRoutes?)`** — Builds a structured index grouping flows by prototype, prototypes by folder, and including canvas entries. Returns `{ folders, prototypes, canvases, globalFlows, sorted }`. Seeds from `.prototype.json` metadata via `listPrototypes()`, supports `hideFlows`, `icon`, `team`, `tags`, `folder`, `isExternal`, `externalUrl`, `gitAuthor`, and `lastModified`. Folder metadata comes from `.folder.json` files. Implicit folders are created when a prototype references a folder that has no metadata file.
+
+The `sorted` object contains pre-sorted variants:
+- `sorted.title` — prototypes, canvases, and folders sorted alphabetically
+- `sorted.updated` — prototypes sorted by `lastModified` (newest first), folders sorted by their most recently updated prototype
 
 ```js
 export function buildPrototypeIndex(knownRoutes = []) {
-  // Seeds from listPrototypes() metadata
+  // Seeds from listPrototypes() and listFolders() metadata
   // Groups flows by prototype prefix (e.g. "Dashboard/default")
-  // Standalone flows go to globalFlows
-  return { prototypes, globalFlows }
+  // Partitions prototypes into folders vs ungrouped
+  // Adds canvas entries from listCanvases()
+  return { folders, prototypes, canvases, globalFlows, sorted }
 }
 ```
 
 ## Dependencies
 
-- [`packages/core/src/loader.js`](./loader.js.md) — `loadFlow`, `listFlows`, `listPrototypes`, `getPrototypeMetadata` for data loading and prototype indexing
+- [`packages/core/src/loader.js`](./loader.js.md) — `loadFlow`, `listFlows`, `listPrototypes`, `getPrototypeMetadata`, `listFolders`, `getFolderMetadata`, `listCanvases`, `getCanvasData` for data loading, prototype/folder/canvas indexing
 
 ## Dependents
 

--- a/.github/architecture/packages/core/src/viewfinder.test.js.md
+++ b/.github/architecture/packages/core/src/viewfinder.test.js.md
@@ -10,11 +10,11 @@ importance: high
 
 ## Goal
 
-Tests for [`packages/core/src/viewfinder.js`](./viewfinder.js.md). Validates `hash` (returns number, deterministic, different for different strings, non-negative), `resolveFlowRoute` (exact case match, case-insensitive, explicit `route` key, absolute route, fallback to root, empty/missing routes, URL encoding, `flowMeta.route` support, priority of top-level `route` over `flowMeta.route`), `getFlowMeta` (with/without `flowMeta`, array authors, missing), deprecated aliases (`resolveSceneRoute`, `getSceneMeta`), and `buildPrototypeIndex` (hideFlows support, defaults).
+Tests for [`packages/core/src/viewfinder.js`](./viewfinder.js.md). Validates `hash` (returns number, deterministic, different for different strings, non-negative), `resolveFlowRoute` (exact case match, case-insensitive, explicit `route` key, absolute route, fallback to root, empty/missing routes, URL encoding, `flowMeta.route` support, priority of top-level `route` over `flowMeta.route`, `_route` inferred from Vite plugin, explicit route wins over `_route`, `meta.default: true` omits `?flow=` param), `getFlowMeta` (with/without `flowMeta`, array authors, missing), deprecated aliases (`resolveSceneRoute`, `getSceneMeta`), and `buildPrototypeIndex` (`hideFlows` support from `meta` and top-level, defaults, folder grouping with metadata, implicit folders, ungrouped prototypes, `lastModified` passthrough).
 
 ## Composition
 
-Six `describe` blocks. Seeds the data index via `init()` in `beforeEach` with a test index containing flows with various route and metadata configurations. Test flows include `flowMeta` with `route` and `author` fields.
+Six `describe` blocks. Seeds the data index via `init()` in `beforeEach` with a test index containing flows with various route, metadata, and `_route` configurations. `buildPrototypeIndex` tests re-initialize the index with prototype metadata, folder metadata, and scoped flows to validate grouping, sorting, and folder behavior.
 
 ## Dependencies
 


### PR DESCRIPTION
Updates 6 stale architecture docs and creates 3 missing ones for core package files.

### Stale docs updated
- **featureFlags.js** — Fixed read priority (localStorage only, removed stale hash references), updated init code sample to show conditional write, updated dependents list
- **loader.test.js** — Added coverage description for scoped resolution, folders, loadObject, deprecated aliases (14 describe blocks now)
- **modes.js** — Added locked mode docs, `isModeSwitcherVisible`, locked behavior in `getCurrentMode` and `activateMode`
- **modes.test.js** — Added locked mode and `isModeSwitcherVisible` test coverage description
- **viewfinder.js** — Added `_route`/`meta.default` support, folders, canvases, sorted output in `buildPrototypeIndex`
- **viewfinder.test.js** — Added `_route`, `meta.default`, folder grouping test coverage description

### New docs created
- **commandActions.js** — Config-driven command menu registry with mode/route filtering, dynamic actions, handler shapes
- **devtools-consumer.js** — Consumer-safe proxy for compiled Svelte UI bundle
- **mountStoryboardCore.js** — Single entry point for consumer app initialization, theme application, toolbar config merging