### PR TITLE
fix: prod/read-only markdown and sticky text behavior

### DIFF
--- a/packages/react/src/canvas/widgets/MarkdownBlock.jsx
+++ b/packages/react/src/canvas/widgets/MarkdownBlock.jsx
@@ -80,6 +80,7 @@ export default function MarkdownBlock({ props, onUpdate }) {
           <div
             className={styles.preview}
             style={!canEdit ? { cursor: 'default' } : undefined}
+            data-canvas-allow-text-selection={!canEdit ? '' : undefined}
             onDoubleClick={canEdit ? () => setEditing(true) : undefined}
             role={canEdit ? 'button' : undefined}
             tabIndex={canEdit ? 0 : undefined}

--- a/packages/react/src/canvas/widgets/MarkdownBlock.jsx
+++ b/packages/react/src/canvas/widgets/MarkdownBlock.jsx
@@ -28,7 +28,9 @@ function renderMarkdown(text) {
 export default function MarkdownBlock({ props, onUpdate }) {
   const content = readProp(props, 'content', markdownSchema)
   const width = readProp(props, 'width', markdownSchema)
+  const canEdit = typeof onUpdate === 'function'
   const [editing, setEditing] = useState(false)
+  const editingActive = canEdit && editing
   const textareaRef = useRef(null)
   const blockRef = useRef(null)
   const [editHeight, setEditHeight] = useState(null)
@@ -38,7 +40,7 @@ export default function MarkdownBlock({ props, onUpdate }) {
   }, [onUpdate])
 
   useEffect(() => {
-    if (editing) {
+    if (editingActive) {
       // Capture the preview height before switching to editor
       if (blockRef.current && !editHeight) {
         setEditHeight(blockRef.current.offsetHeight)
@@ -49,7 +51,7 @@ export default function MarkdownBlock({ props, onUpdate }) {
     } else {
       setEditHeight(null)
     }
-  }, [editing, editHeight])
+  }, [editingActive, editHeight])
 
   return (
     <WidgetWrapper>
@@ -58,7 +60,7 @@ export default function MarkdownBlock({ props, onUpdate }) {
         className={styles.block}
         style={{ width, minHeight: editHeight || undefined }}
       >
-        {editing ? (
+        {editingActive ? (
           <textarea
             ref={textareaRef}
             className={styles.editor}
@@ -77,12 +79,15 @@ export default function MarkdownBlock({ props, onUpdate }) {
         ) : (
           <div
             className={styles.preview}
-            onDoubleClick={() => setEditing(true)}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => { if (e.key === 'Enter') setEditing(true) }}
+            style={!canEdit ? { cursor: 'default' } : undefined}
+            onDoubleClick={canEdit ? () => setEditing(true) : undefined}
+            role={canEdit ? 'button' : undefined}
+            tabIndex={canEdit ? 0 : undefined}
+            onKeyDown={canEdit ? (e) => { if (e.key === 'Enter') setEditing(true) } : undefined}
             dangerouslySetInnerHTML={{
-              __html: renderMarkdown(content) || '<p class="placeholder">Double-click to edit…</p>',
+              __html: renderMarkdown(content) || (canEdit
+                ? '<p class="placeholder">Double-click to edit…</p>'
+                : '<p class="placeholder">No content</p>'),
             }}
           />
         )}

--- a/packages/react/src/canvas/widgets/MarkdownBlock.jsx
+++ b/packages/react/src/canvas/widgets/MarkdownBlock.jsx
@@ -39,6 +39,15 @@ export default function MarkdownBlock({ props, onUpdate }) {
     onUpdate?.({ content: e.target.value })
   }, [onUpdate])
 
+  const handleReadOnlyCopy = useCallback((e) => {
+    if (canEdit) return
+    e.preventDefault()
+    e.stopPropagation()
+    if (e.clipboardData?.setData) {
+      e.clipboardData.setData('text/plain', content || '')
+    }
+  }, [canEdit, content])
+
   useEffect(() => {
     if (editingActive) {
       // Capture the preview height before switching to editor
@@ -81,6 +90,8 @@ export default function MarkdownBlock({ props, onUpdate }) {
             className={styles.preview}
             style={!canEdit ? { cursor: 'default' } : undefined}
             data-canvas-allow-text-selection={!canEdit ? '' : undefined}
+            onClick={!canEdit ? (e) => e.stopPropagation() : undefined}
+            onCopy={!canEdit ? handleReadOnlyCopy : undefined}
             onDoubleClick={canEdit ? () => setEditing(true) : undefined}
             role={canEdit ? 'button' : undefined}
             tabIndex={canEdit ? 0 : undefined}

--- a/packages/react/src/canvas/widgets/MarkdownBlock.test.jsx
+++ b/packages/react/src/canvas/widgets/MarkdownBlock.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import MarkdownBlock from './MarkdownBlock.jsx'
+
+describe('MarkdownBlock', () => {
+  it('does not enter edit mode when onUpdate is unavailable (read-only/prod)', () => {
+    render(<MarkdownBlock props={{ content: 'Hello', width: 420 }} />)
+
+    fireEvent.doubleClick(screen.getByText('Hello'))
+
+    expect(screen.queryByRole('textbox')).toBeNull()
+  })
+
+  it('enters edit mode when onUpdate is available', () => {
+    const onUpdate = vi.fn()
+    render(<MarkdownBlock props={{ content: 'Hello', width: 420 }} onUpdate={onUpdate} />)
+
+    fireEvent.doubleClick(screen.getByText('Hello'))
+
+    expect(screen.queryByRole('textbox')).not.toBeNull()
+  })
+
+  it('shows a non-editable empty-state message in read-only mode', () => {
+    render(<MarkdownBlock props={{ content: '', width: 420 }} />)
+
+    expect(screen.getByText('No content')).toBeTruthy()
+    expect(screen.queryByText('Double-click to edit…')).toBeNull()
+  })
+})

--- a/packages/react/src/canvas/widgets/MarkdownBlock.test.jsx
+++ b/packages/react/src/canvas/widgets/MarkdownBlock.test.jsx
@@ -4,11 +4,12 @@ import MarkdownBlock from './MarkdownBlock.jsx'
 
 describe('MarkdownBlock', () => {
   it('does not enter edit mode when onUpdate is unavailable (read-only/prod)', () => {
-    render(<MarkdownBlock props={{ content: 'Hello', width: 420 }} />)
+    const { container } = render(<MarkdownBlock props={{ content: 'Hello', width: 420 }} />)
 
     fireEvent.doubleClick(screen.getByText('Hello'))
 
     expect(screen.queryByRole('textbox')).toBeNull()
+    expect(container.querySelector('[data-canvas-allow-text-selection]')).not.toBeNull()
   })
 
   it('enters edit mode when onUpdate is available', () => {

--- a/packages/react/src/canvas/widgets/MarkdownBlock.test.jsx
+++ b/packages/react/src/canvas/widgets/MarkdownBlock.test.jsx
@@ -27,4 +27,27 @@ describe('MarkdownBlock', () => {
     expect(screen.getByText('No content')).toBeTruthy()
     expect(screen.queryByText('Double-click to edit…')).toBeNull()
   })
+
+  it('stops click propagation in read-only mode', () => {
+    const onParentClick = vi.fn()
+    render(
+      <div onClick={onParentClick}>
+        <MarkdownBlock props={{ content: 'Hello', width: 420 }} />
+      </div>
+    )
+
+    fireEvent.click(screen.getByText('Hello'))
+
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('copies markdown source in read-only mode', () => {
+    render(<MarkdownBlock props={{ content: '**Hello**\n- item', width: 420 }} />)
+
+    const preview = screen.getByText('Hello').closest('[data-canvas-allow-text-selection]')
+    const setData = vi.fn()
+    fireEvent.copy(preview, { clipboardData: { setData } })
+
+    expect(setData).toHaveBeenCalledWith('text/plain', '**Hello**\n- item')
+  })
 })

--- a/packages/react/src/canvas/widgets/StickyNote.jsx
+++ b/packages/react/src/canvas/widgets/StickyNote.jsx
@@ -17,21 +17,23 @@ export default function StickyNote({ props, onUpdate, resizable }) {
   const color = readProp(props, 'color', stickyNoteSchema)
   const width = readProp(props, 'width', stickyNoteSchema)
   const height = readProp(props, 'height', stickyNoteSchema)
+  const canEdit = typeof onUpdate === 'function'
   const palette = COLORS[color] ?? COLORS.yellow
   const textareaRef = useRef(null)
   const stickyRef = useRef(null)
   const [editing, setEditing] = useState(false)
+  const editingActive = canEdit && editing
 
   const handleResize = useCallback((w, h) => {
     onUpdate?.({ width: w, height: h })
   }, [onUpdate])
 
   useEffect(() => {
-    if (editing && textareaRef.current) {
+    if (editingActive && textareaRef.current) {
       textareaRef.current.focus()
       textareaRef.current.selectionStart = textareaRef.current.value.length
     }
-  }, [editing])
+  }, [editingActive])
 
   const handleTextChange = useCallback((e) => {
     onUpdate?.({ text: e.target.value })
@@ -51,15 +53,16 @@ export default function StickyNote({ props, onUpdate, resizable }) {
       >
         <p
           className={styles.text}
-          style={editing ? { visibility: 'hidden' } : undefined}
-          onDoubleClick={() => setEditing(true)}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => { if (e.key === 'Enter') setEditing(true) }}
+          style={editingActive ? { visibility: 'hidden' } : undefined}
+          data-canvas-allow-text-selection={!canEdit ? '' : undefined}
+          onDoubleClick={canEdit ? () => setEditing(true) : undefined}
+          role={canEdit ? 'button' : undefined}
+          tabIndex={canEdit ? 0 : undefined}
+          onKeyDown={canEdit ? (e) => { if (e.key === 'Enter') setEditing(true) } : undefined}
         >
-          {text || 'Double-click to edit…'}
+          {text || (canEdit ? 'Double-click to edit…' : 'No content')}
         </p>
-        {editing && (
+        {editingActive && (
           <textarea
             ref={textareaRef}
             className={styles.textarea}

--- a/packages/react/src/canvas/widgets/StickyNote.test.jsx
+++ b/packages/react/src/canvas/widgets/StickyNote.test.jsx
@@ -99,4 +99,18 @@ describe('StickyNote', () => {
 
     expect(onUpdate).toHaveBeenCalledWith({ width: 180, height: 60 })
   })
+
+  it('does not enter edit mode without onUpdate (read-only/prod)', () => {
+    const { container } = render(<StickyNote props={{ text: 'Read me' }} />)
+    const text = container.querySelector('p')
+    fireEvent.doubleClick(text)
+    expect(container.querySelector('textarea')).toBeNull()
+    expect(container.querySelector('[data-canvas-allow-text-selection]')).not.toBeNull()
+  })
+
+  it('shows non-editable empty-state text in read-only mode', () => {
+    const { container } = render(<StickyNote props={{ text: '' }} />)
+    expect(container.textContent).toContain('No content')
+    expect(container.textContent).not.toContain('Double-click to edit…')
+  })
 })


### PR DESCRIPTION
## Summary
- block markdown edit-mode entry when updates are unavailable in prod/read-only paths
- keep markdown editable in local dev/read-write mode
- allow text selection for markdown and sticky content in prod/read-only mode
- add regression tests for markdown and sticky read-only behavior

## Why
One-off 3.11.0 stabilization: in prod/read-only mode markdown was entering an unusable edit UI, and text needed to remain selectable for markdown/sticky content.

## Validation
- npm run test -- packages/react/src/canvas/widgets/MarkdownBlock.test.jsx packages/react/src/canvas/widgets/StickyNote.test.jsx
- npm run test:react
- npm run build
- npx eslint packages/react/src/canvas/widgets/MarkdownBlock.jsx packages/react/src/canvas/widgets/MarkdownBlock.test.jsx packages/react/src/canvas/widgets/StickyNote.jsx packages/react/src/canvas/widgets/StickyNote.test.jsx