### PR TITLE
docs: reframe README with conceptual UI-first guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,190 +1,120 @@
 # Storyboard
 
-> [!NOTE]  
-> This README is a work in progress 
+Storyboard is a framework for building **stateful prototypes**: real UI, structured local data, and shareable URL-based state in one workflow.
 
-Storyboard is a design tool for prototyping that runs entirely on GitHub. It bundles four key capabilities in a single platform:
+It is designed as a middle ground between static mockups and full app environments. You can model realistic scenarios, review interaction details, and deploy as a static site without wiring APIs or backend infrastructure.
 
-1. A framework for building **stateful prototypes** in React
-2. An overlay of design tools for inspecting, documenting and interacting with your prototypes
-3. An interactive canvas where you can add components, prototypes, Figma files, and more
-4. The *viewfinder*, a homepage for every prototype created by your team.
+## Why teams use it
 
-Storyboard is free and open-source, and can be deployed internally for your team by forking the example repository and turning on GitHub Pages.
+- **Data-first prototyping**: prototype state lives in JSON files, not hardcoded component fixtures.
+- **Shareable interactions**: runtime changes are encoded in the URL, so anyone can open the exact same state.
+- **Scenario-driven work**: switch between flows (default, empty, error, admin, etc.) without changing UI code.
+- **UI + tooling together**: build pages and use built-in tools (Create, Flow switcher, Inspector, Canvas, Viewfinder) in the same app.
 
-<!-- lots of medias -->
+## Quick start
 
-### Getting Started
-
-Storyboard is a static Svelte + React application that only requires GitHub Pages to be deployed. It can also be easily deployed on other hosts like Vercel and Netlify, but GH Pages has the benefit of authentication being tied to your repository.
-
-1. Fork the example repository inside your GitHub organization
-2. Enable GitHub Pages deployment (or set your external host)
-3. Add your team as collaborators on the repository so they can see the GitHub Pages
-
-That's it! You can now start creating and pushing prototypes.
-
-### Creating prototypes
-
-Start by cloning the repository locally, when run `npm install` and `npm run dev` to start building. This will start your storyboard instance on `http://localhost:1234`
-
-Every prototype is a folder in the `/src/prototypes` directory. To create a new prototype, you can do it in two different ways:
-
-- On the UI, go to the Create tool and choose `Create Prototype`. It will provide you with a set of options and create the right folder and files to start prototype.
-
-<!-- media -->
-
-- Ask your AI assistant (e.g.: Copilot or Claude Code) `create a prototype for me`. This will run a dedicated skill that will ask the same set of options as the UI and create the folder and files for your prototype.
-
-<!-- media -->
-
-Storyboard only runs React prototypes at the moment. Open a discussion if you'd like to see other frontend frameworks supported.
-
-#### Live editing 
-
-> Wait, I can create a prototype by editing the UI? How does this work?
-
-Yes! Storyboard runs a two-way dev server on your local machine that lets you **live edit** the code from your browser. 
-
-This means you can edit the prototype code manually, but storyboard can also edit the code on your repository *from the browser UI.* 
-
-Think of storyboard as a full stack web app running on your machine... it's just that the repository itself is your database! 
-
-<!-- some medias -->
-
-**Live editing** is only available on your local developer environment (for now).
-
-#### Flows
-
-A single prototype can contain multiple flows. The idea is that for the same exploration, you might want to represent e.g.: an empty state, a default state, an error state, etc...
-
-Flows allow you to do two things:
-
-1. Define entrypoint URLs to any place in your prototype. This could be as simple as a `Landing page` and `Dashboard` flow that take users directly to these pages for convenience of navigation.
-
-<!-- flow media -->
-
-2. Define an initial set of data for that flow. Useful for populating pages that read data objects, and setting up states such as e.g.: `empty state`, `error state` that are defined by the data and not hardcoded in the layout.
-<!-- flow media -->
-
-Learn more in < Getting started with state-driven prototypes >.
-
-#### Components, Templates, Recipes, Styles
-
-You can provide an easy way for your team to create prototypes that match your product's pages, patterns, and styles. 
-
-On top of importing your design system, you can create folders in to provide shared utilities for all prototypes: `src/components`, `src/templates`, `src/recipes`, `src/styles`, etc. Templates and Recipes in these folders will be listed as options for prototype creation.
-
-To import any of these shared assets on a file, just do e.g.:
-
-`import Application from "@/templates/Application.tsx"`
-
-You don't need to worry with file paths, the `@/` works from anywhere in the repo.
-
-#### Templates vs Recipes
-
-Recipes are Templates with specific data attached. For example, you might want to have your Application template with navigation that reflects a user account, but also a team account. 
-
-Instead of creating two Templates that duplicate the same code with slightly different data, you can create two Recipes! Each one using the same Template, but loading different sets of data. 
-
-Jump here to [learn how to create a recipe] – but you might want to learn about state data first and how we handle it. Let's go:
-
-### Getting started with state-driven prototypes
-
-Storyboard is **not** made to use real data from APIs.
-
-> Wait, what?
-
-Yeah, that's right. Real data can be useful in certain scenarios, but *prototyping* with real data from APIs is counter-productive. Here's why:
-
-- Adding APIs to your prototype adds a lot of complexity for authentication and hosting.
-- Even if you have APIs properly set up, your account might not have the data you need to design your desired flows e.g.: an account that has 2000 tickets, an enterprise account with invoiced billing configured, a-post-with-really-long-title-so-you-can-see-if-the-UI-breaks.
-- Assuming you got the real data you need, the _users_ of your prototype might not have useful data in their account to test the experience as you intended to.
-
-_* gently puts down microphone *_
-
-OK, with that out of the way... what should you use instead?
-
-### Storyboard data files
-
-Storyboard prototypes are powered by data files that live in your repository. The framework also provides an easy way for your front-end to read from those files. 
-
-Here's the 3 types of data files:
-
-| Type | Purpose | Name |
-|--------|---------|---------|
-| `.flow.json` | Data to represent a specific flow | `emptyState.flow.json` |
-
-In this example, a flow that has all the fields used in a page, but with empty values. Your components could render your empty state experience based on this.
-
-| Type | Purpose | Name |
-|--------|---------|---------|
-| `.object.json` | Reusable data object | `teamNavigation.object.json` | 
-
-An object can be used anywhere, but this could be imported by a Recipe to show what navigation should contain for a Team page! Others could be `userNavigation.object.json`, `loggedOutNavigation.object.json`, etc...
-
-| Type | Purpose | Name |
-|--------|---------|---------|
-| `.record.json` | Repeatable collection | `tickets.record.json` | 
-
-If you're prototyping an issue-tracking tool, you can have 100 tickets described in a record file, and read them from the UI. It's like an API in your pocket!
-
----
-
-Data files must be placed inside each prototype directory, and are not meant to be shared across prototypes. This is so that they can be easily read in your prototype without paths:
-
-```jsx
-
-import { useObject } from '@dfosco/storyboard-react'
-
-const user = useObject('teamNavigation')
+```bash
+npm install
+npm run dev
 ```
 
-This will import the data from `teamNavigation.object.json` in your prototype regardless of the location of the file, as long as the file is in `/src/prototypes/your-prototype`. 
+This starts a local Storyboard instance (usually `http://localhost:1234`).
 
-Different prototypes can have objects with the same name too, and will match their local copies.
+```bash
+npm run build
+```
 
-Let's dive deeper.
+The output is static and can be deployed to GitHub Pages, Vercel, Netlify, or any static host.
 
-#### Using object hooks
+## What you see in the UI
 
-#### Using flow hooks
+- **Viewfinder** (`/`): dashboard of all prototypes (and canvases), including grouped folders and external prototypes.
+- **Toolbar** (bottom-right): command menu, flow switcher, inspector, docs, and dev tools.
+- **Create menu**: scaffold prototypes, flows, and canvases from a form.
+- **Canvas**: free-form board for notes, embeds, links, and prototype references.
 
-#### Using record hooks
+## Create a prototype (UI-first)
 
-#### Downsides to this approach
+1. Run `npm run dev`.
+2. Open the toolbar and choose **Create -> New prototype**.
+3. Fill metadata/template options and submit.
+4. Storyboard generates the starter files in `src/prototypes/`.
 
-As with any optimization, there are downsides to this approach. We are optimizing for more interactive and stateful prototypes, and in doing so reducing fidelity to your own product's codebase.
+This is local live editing: during local dev, UI actions can write files directly into your repository.
 
-The code of your prototype will handle data in a way that's fundamentally different than your product — you're not talking to your own APIs, and you're not querying from your database.
+## Create a prototype (files-first)
 
-Storyboard prototypes are meant to be used as a reference for **layout and interaction**, and designers and developers are expected to adjust the code to match production needs. It is a prototype after all, please don't copy and paste the code 😅
+You can also create the same structure manually:
 
-### Design Tools
+```text
+src/prototypes/MyProfile/
+  my-profile.prototype.json
+  default.flow.json
+  index.jsx
+```
 
-#### Create
+```json
+// my-profile.prototype.json
+{
+  "meta": {
+    "title": "My Profile",
+    "description": "Simple profile prototype",
+    "author": ["your-name"]
+  }
+}
+```
 
-#### Autosync
+```json
+// default.flow.json
+{
+  "user": {
+    "name": "Jane Doe",
+    "bio": "Designer & developer",
+    "avatar": "https://avatars.githubusercontent.com/u/1?v=4"
+  }
+}
+```
 
-#### Theme switcher
+```jsx
+// index.jsx
+import { Avatar, Heading, Text } from '@primer/react'
+import { useFlowData } from '@dfosco/storyboard-react'
 
-#### Inspect 
+export default function MyProfilePage() {
+  const user = useFlowData('user')
 
-#### Comments
+  return (
+    <main>
+      <Avatar src={user?.avatar} size={64} />
+      <Heading as="h1">{user?.name ?? 'Unknown user'}</Heading>
+      <Text>{user?.bio ?? 'No bio yet'}</Text>
+    </main>
+  )
+}
+```
 
-#### Flow switcher
+## Core data model
 
-#### Feature flags
+| File type | Purpose | Example |
+| --- | --- | --- |
+| `.prototype.json` | Prototype metadata and registration | `my-profile.prototype.json` |
+| `.flow.json` | Scenario/state snapshot used as page context | `default.flow.json` |
+| `.object.json` | Reusable data fragment shared by flows | `navigation.object.json` |
+| `.record.json` | Collection data for list/detail routes | `posts.record.json` |
 
+Notes:
+- Flows can reference objects with `{"$ref": "object-name"}`.
+- Prototype-local data is scoped automatically, with fallback to global data.
+- Components should always handle missing data with optional chaining/fallbacks.
 
-### Canvas
+## URL-driven state model
 
-#### Sticky Notes
+- `?flow=empty-state` selects a different flow snapshot.
+- `#user.name=Alice` overrides a value at runtime.
 
-#### Markdown blocks
+That combination makes states reproducible, linkable, and fast to iterate on.
 
-#### Prototype Embeds
+## Learn more
 
-#### Figma Embeds
-
-#### Local Components
+- Full docs: [`DOCS.md`](./DOCS.md)
+- Architecture docs: [`.github/architecture/`](./.github/architecture/)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Storyboard
 
-Storyboard is a framework for building **stateful prototypes**: real UI, structured local data, and shareable URL-based state in one workflow.
+Storyboard brings four concepts into one workflow:
 
-It is designed as a middle ground between static mockups and full app environments. You can model realistic scenarios, review interaction details, and deploy as a static site without wiring APIs or backend infrastructure.
+- **Stateful prototype framework**: build real UI backed by local structured data.
+- **Design tools in-context**: inspect, discuss, and iterate directly in the running prototype.
+- **Canvas workspace**: arrange notes, embeds, links, and prototype references on a free-form board.
+- **Viewfinder home**: navigate all prototypes and canvases from a single dashboard.
+
+It is designed as a middle ground between static mockups and full app environments. You can model realistic scenarios, inspect and discuss interactions, and deploy as a static site without wiring APIs or backend infrastructure.
 
 ## Why teams use it
 


### PR DESCRIPTION
## Summary
- rewrite the root README to focus on Storyboard concepts first
- add a clear UI-first creation flow via toolbar Create -> New prototype
- keep a concise files-first path and core data model reference
- link readers to DOCS.md and architecture docs for full depth

## Why
The previous README mixed partial sections and placeholders. This version aims for a clearer middle ground between conceptual framing and practical onboarding.