### PR TITLE
3.11.0  canvas route 404

### DIFF
--- a/.github/plans/3.11.0.md
+++ b/.github/plans/3.11.0.md
@@ -1,0 +1,27 @@
+# Canvas route 404 fallback (3.11.0)
+
+## Problem statement
+
+Canvas URLs that do not map to a known canvas currently fall through normal route resolution, which does not provide a canvas-specific not-found experience. We need a simple 404 for missing canvas routes that points users back to the index page.
+
+## Approach
+
+Add a targeted canvas not-found branch in `StoryboardProvider` that only activates for `/canvas` paths when no registered canvas route matches. Reuse existing lightweight error styling and render a simple message with a link to `/`.
+
+## Files to change
+
+- `packages/react/src/context.jsx` — detect unmatched canvas paths and render a simple 404 UI with index link.
+- `packages/react/src/context.test.jsx` — add coverage for missing canvas route behavior.
+
+## Steps
+
+1. Inspect current canvas route matching in `context.jsx` and define an `isMissingCanvasRoute` condition based on `location.pathname` and `canvasName`.
+2. Render a simple not-found block before flow loading for missing canvas routes with a direct link to `/`.
+3. Add tests in `context.test.jsx` to assert the canvas 404 message and index link are rendered for unknown `/canvas/*` paths.
+4. Run lint, build, and test commands; adjust implementation if any regressions surface.
+
+## Edge cases & risks
+
+- `/canvas` (with or without trailing slash) should be treated as canvas namespace and show the fallback when no matching canvas exists.
+- Existing valid canvas routes must remain unchanged and continue rendering `CanvasPage`.
+- Keep fallback scoped to canvas paths so non-canvas routes keep their current behavior.

--- a/packages/react/src/__mocks__/virtual-storyboard-data-index.js
+++ b/packages/react/src/__mocks__/virtual-storyboard-data-index.js
@@ -1,3 +1,4 @@
 // Stub for the Vite virtual module used by context.jsx
 // The actual init() seeding is done in each test's beforeEach
+export const canvases = {}
 export default {}

--- a/packages/react/src/context.jsx
+++ b/packages/react/src/context.jsx
@@ -22,6 +22,11 @@ function matchCanvasRoute(pathname) {
   return canvasRouteMap.get(normalized) || null
 }
 
+function isCanvasPath(pathname) {
+  const normalized = pathname.replace(/\/+$/, '') || '/'
+  return normalized === '/canvas' || normalized.startsWith('/canvas/')
+}
+
 /**
  * Derives the top-level prototype name from a pathname.
  * "/Dashboard" → "Dashboard", "/Dashboard/sub" → "Dashboard"
@@ -62,6 +67,10 @@ export default function StoryboardProvider({ flowName, sceneName, recordName, re
 
   // Canvas route detection — matches current URL against registered canvas routes
   const canvasName = useMemo(() => matchCanvasRoute(location.pathname), [location.pathname])
+  const isMissingCanvasRoute = useMemo(
+    () => isCanvasPath(location.pathname) && !canvasName,
+    [location.pathname, canvasName],
+  )
 
   const searchParams = new URLSearchParams(location.search)
   const sceneParam = searchParams.get('flow') || searchParams.get('scene')
@@ -70,7 +79,7 @@ export default function StoryboardProvider({ flowName, sceneName, recordName, re
 
   // Resolve flow name with prototype scoping (skip for canvas pages)
   const activeFlowName = useMemo(() => {
-    if (canvasName) return null
+    if (canvasName || isMissingCanvasRoute) return null
     const requested = sceneParam || flowName || sceneName
     if (requested) {
       // Allow fully-scoped flow names from URLs/widgets without re-prefixing
@@ -94,7 +103,7 @@ export default function StoryboardProvider({ flowName, sceneName, recordName, re
     // 4. Global default — or null if no flow exists at all
     if (flowExists('default')) return 'default'
     return null
-  }, [canvasName, sceneParam, flowName, sceneName, prototypeName, pageFlow])
+  }, [canvasName, isMissingCanvasRoute, sceneParam, flowName, sceneName, prototypeName, pageFlow])
 
   // Auto-install body class sync (sb-key--value classes on <body>)
   useEffect(() => installBodyClassSync(), [])
@@ -117,7 +126,7 @@ export default function StoryboardProvider({ flowName, sceneName, recordName, re
 
   // Skip flow loading for canvas pages and flow-less pages
   const { data, error } = useMemo(() => {
-    if (canvasName) return { data: null, error: null }
+    if (canvasName || isMissingCanvasRoute) return { data: null, error: null }
     if (!activeFlowName) return { data: {}, error: null }
     try {
       let flowData = loadFlow(activeFlowName)
@@ -136,7 +145,7 @@ export default function StoryboardProvider({ flowName, sceneName, recordName, re
     } catch (err) {
       return { data: null, error: err.message }
     }
-  }, [canvasName, activeFlowName, recordName, recordParam, params, prototypeName])
+  }, [canvasName, isMissingCanvasRoute, activeFlowName, recordName, recordParam, params, prototypeName])
 
   // Canvas pages get their own rendering path — no flow data needed
   if (canvasName) {
@@ -154,6 +163,27 @@ export default function StoryboardProvider({ flowName, sceneName, recordName, re
           <CanvasPageLazy name={canvasName} />
         </Suspense>
       </StoryboardContext.Provider>
+    )
+  }
+
+  if (isMissingCanvasRoute) {
+    const currentUrl = `${location.pathname}${location.search}`
+    const truncatedUrl = currentUrl.length > 60
+      ? currentUrl.slice(0, 60) + '…'
+      : currentUrl
+
+    return (
+      <main className={styles.container}>
+        <div className={styles.banner}>
+          <strong>Canvas not found</strong>
+          No canvas matches this route.
+        </div>
+        <p className={styles.meta}>
+          Tried to open{' '}
+          <a href={currentUrl} title={currentUrl}>{truncatedUrl}</a>
+        </p>
+        <a className={styles.homeLink} href="/">← Go to index page</a>
+      </main>
     )
   }
 

--- a/packages/react/src/context.test.jsx
+++ b/packages/react/src/context.test.jsx
@@ -280,4 +280,17 @@ describe('StoryboardProvider', () => {
     )
     expect(screen.getByTestId('ctx')).toHaveTextContent('Global Default')
   })
+
+  it('shows a simple 404 for unknown canvas routes with an index link', () => {
+    mockUseLocation.mockReturnValue({ pathname: '/canvas/unknown-board', search: '', hash: '' })
+
+    render(
+      <StoryboardProvider>
+        <ContextReader />
+      </StoryboardProvider>,
+    )
+
+    expect(screen.getByText('Canvas not found')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /go to index page/i })).toHaveAttribute('href', '/')
+  })
 })


### PR DESCRIPTION
- **fix: add canvas route 404 fallback**
- **test: cover unknown canvas route fallback**
